### PR TITLE
morton: add public method to return origin of morton obj

### DIFF
--- a/include/sctl/morton.hpp
+++ b/include/sctl/morton.hpp
@@ -228,6 +228,14 @@ template <Integer DIM = 3> class Morton {
     return out;
   }
 
+  template <typename Real>
+  std::array<Real, DIM> origin() const {
+    constexpr Real factor = 1.0 / Real{maxCoord};
+    std::array<Real, DIM> x_real;
+    for (int i = 0; i < DIM; ++i) x_real[i] = x[i] * factor;
+    return x_real;
+  }
+
  private:
   static constexpr UINT_T maxCoord = ((UINT_T)1) << (MAX_DEPTH);
 


### PR DESCRIPTION
`x` is private and in a format requiring knowledge of how to convert to lab coordinates. This method returns a `std::array` object representing the origin of the object in the requested type of `Real` 