### PR TITLE
include <array> in profile to handle incomplete type errors

### DIFF
--- a/include/sctl/profile.hpp
+++ b/include/sctl/profile.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 #include <stack>
+#include <array>
 #include <atomic>
 
 #ifndef SCTL_PROFILE


### PR DESCRIPTION
Fixes incomplete type issue: 
```
/blah/extern/SCTL/include/sctl/profile.txx:237:45: error: field 'counters' has incomplete type 'std::array<std::atomic<long int>, 16>'
  237 |     std::array<std::atomic<Long>, Nfield+1> counters;
```