### PR TITLE
openmp: add wrappers to omp_* calls to allow non-openmp builds

### DIFF
--- a/include/sctl/boundary_integral.txx
+++ b/include/sctl/boundary_integral.txx
@@ -1,7 +1,6 @@
 #ifndef _SCTL_BOUNDARY_INTEGRAL_TXX_
 #define _SCTL_BOUNDARY_INTEGRAL_TXX_
 
-#include <omp.h>                       // for omp_get_num_threads, omp_get_t...
 #include <algorithm>                   // for lower_bound, max, min, upper_b...
 #include <map>                         // for map
 #include <set>                         // for set, __tree_const_iterator
@@ -10,7 +9,7 @@
 #include <typeinfo>                    // for type_info
 #include <utility>                     // for pair, make_pair
 
-#include "sctl/common.hpp"             // for Long, Integer, SCTL_ASSERT
+#include "sctl/common.hpp"             // for Long, Integer, SCTL_ASSERT, SCTL_GET_(...)
 #include "sctl/boundary_integral.hpp"  // for BoundaryIntegralOp, BuildNearList
 #include "sctl/comm.hpp"               // for Comm, CommOp
 #include "sctl/comm.txx"               // for Comm::Allreduce, Comm::Size
@@ -408,8 +407,8 @@ namespace sctl {
       near_elem_dsp.ReInit(Nelem);
       #pragma omp parallel
       { // Set near_elem_cnt, near_elem_dsp
-        const Integer tid = omp_get_thread_num();
-        const Integer omp_p = omp_get_num_threads();
+        const Integer tid = SCTL_GET_THREAD_NUM();
+        const Integer omp_p = SCTL_GET_NUM_THREADS();
         const Long elem_idx0 = Nelem*(tid+0)/omp_p;
         const Long elem_idx1 = Nelem*(tid+1)/omp_p;
         for (Long i = elem_idx0; i < elem_idx1; i++) {
@@ -448,8 +447,8 @@ namespace sctl {
       near_trg_dsp.ReInit(Ntrg);
       #pragma omp parallel
       { // Set near_trg_cnt, near_trg_dsp
-        const Integer tid = omp_get_thread_num();
-        const Integer omp_p = omp_get_num_threads();
+        const Integer tid = SCTL_GET_THREAD_NUM();
+        const Integer omp_p = SCTL_GET_NUM_THREADS();
         const Long trg_idx0 = Ntrg*(tid+0)/omp_p;
         const Long trg_idx1 = Ntrg*(tid+1)/omp_p;
         for (Long i = trg_idx0; i < trg_idx1; i++) {
@@ -977,7 +976,7 @@ namespace sctl {
 
         constexpr Long cache_line_size = 512;
         const Long N_near = near_elem_dsp[Nelem-1] + near_elem_cnt[Nelem-1];
-        const Long omp_chunk_size = std::max(N_near/omp_get_max_threads()/32, (cache_line_size+KDIM1_-1)/KDIM1_);
+        const Long omp_chunk_size = std::max(N_near/SCTL_GET_MAX_THREADS()/32, (cache_line_size+KDIM1_-1)/KDIM1_);
         #pragma omp parallel for schedule(dynamic,omp_chunk_size)
         for (Long i = 0; i < N_near; i++) { // loop over all pairs of elements and their near targets
           const Long elem_idx = std::lower_bound(near_elem_dsp.begin(), near_elem_dsp.end(), i+1) - near_elem_dsp.begin() - 1;
@@ -1065,7 +1064,7 @@ namespace sctl {
       for (Long i = 0; i < Nlst; i++) { // Subtract direct-interaction part from K_near
         const auto& elem_lst = elem_lst_map.at(elem_lst_name[i]);
         if (elem_lst->MatrixFree()) continue;
-        #pragma omp parallel for if(elem_lst_cnt[i] > omp_get_max_threads()) schedule(dynamic)
+        #pragma omp parallel for if(elem_lst_cnt[i] > SCTL_GET_MAX_THREADS()) schedule(dynamic)
         for (Long j = 0; j < elem_lst_cnt[i]; j++) { // subtract direct sum
           const Long elem_idx = elem_lst_dsp[i]+j;
           const Long trg_cnt = near_elem_cnt[elem_idx];
@@ -1208,7 +1207,7 @@ namespace sctl {
     }
 
     Vector<Real> U_near(Nelem ? (near_elem_dsp[Nelem-1]+near_elem_cnt[Nelem-1])*KDIM1_ : 0);
-    #pragma omp parallel for if(Nelem > omp_get_max_threads()) schedule(dynamic)
+    #pragma omp parallel for if(Nelem > SCTL_GET_MAX_THREADS()) schedule(dynamic)
     for (Long elem_idx = 0; elem_idx < Nelem; elem_idx++) { // Compute near-interactions from precomputed operator matrix
       const Long src_dof = elem_nds_cnt[elem_idx]*KDIM0;
       const Long trg_dof = near_elem_cnt[elem_idx]*KDIM1_;
@@ -1228,7 +1227,7 @@ namespace sctl {
       const auto& name = elem_lst_name[i];
       const auto& elem_lst = elem_lst_map.at(name);
       const auto& elem_data = elem_data_map.at(name);
-      #pragma omp parallel for if(elem_lst_cnt[i]>4*omp_get_max_threads()) schedule(dynamic)
+      #pragma omp parallel for if(elem_lst_cnt[i]>4*SCTL_GET_MAX_THREADS()) schedule(dynamic)
       for (Long j = 0; j < elem_lst_cnt[i]; j++) {
         const Long elem_idx = elem_lst_dsp[i]+j;
         const Long Ntrg = near_elem_cnt[elem_idx];

--- a/include/sctl/comm.txx
+++ b/include/sctl/comm.txx
@@ -1671,7 +1671,7 @@ template <class Type, class Compare> void Comm::HyperQuickSort(const Vector<Type
   {  // Get comm size and rank.
     npes = Size();
     myrank = Rank();
-    omp_p = omp_get_max_threads();
+    omp_p = SCTL_GET_MAX_THREADS();
   }
   srand(myrank);
 

--- a/include/sctl/common.hpp
+++ b/include/sctl/common.hpp
@@ -10,6 +10,21 @@
 #  define SCTL_DATA_PATH ./data/
 #endif
 
+#ifdef _OPENMP
+#include <omp.h>
+#define SCTL_GET_WTIME()       (omp_get_wtime())
+#define SCTL_GET_NUM_THREADS() (omp_get_num_threads())
+#define SCTL_GET_MAX_THREADS() (omp_get_max_threads())
+#define SCTL_GET_THREAD_NUM()  (omp_get_thread_num())
+#else
+#include <chrono>
+#define SCTL_GET_WTIME() \
+    (std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch()).count())
+#define SCTL_GET_NUM_THREADS() (1)
+#define SCTL_GET_MAX_THREADS() (1)
+#define SCTL_GET_THREAD_NUM()  (0)
+#endif
+
 //#ifndef SCTL_NAMESPACE
 //#define SCTL_NAMESPACE sctl
 //#endif

--- a/include/sctl/matrix.txx
+++ b/include/sctl/matrix.txx
@@ -3,14 +3,13 @@
 
 #include <ios>                   // for ios
 #include <ostream>               // for ostream
-#include <omp.h>                  // for omp_get_max_threads, omp_get_thread...
 #include <stdio.h>                // for fclose, fopen, fread, fwrite, FILE
 #include <cassert>                // for assert
 #include <cstdint>                // for uint64_t
 #include <iomanip>                // for operator<<, setiosflags, setprecision
 #include <iostream>               // for basic_ostream, char_traits, operator<<
 
-#include "sctl/common.hpp"        // for Long, SCTL_ASSERT, Integer, SCTL_AS...
+#include "sctl/common.hpp"        // for Long, SCTL_ASSERT, Integer, SCTL_AS, SCTL_GET_(...)...
 #include "sctl/matrix.hpp"        // for Matrix, operator<<
 #include "sctl/iterator.hpp"      // for Iterator, ConstIterator
 #include "sctl/iterator.txx"      // for Iterator::Iterator<ValueType>, Iter...
@@ -430,7 +429,7 @@ template <class ValueType> void Matrix<ValueType>::RowPerm(const Permutation<Val
     for (Long j = 0; j < d1; j++) M_[j] *= s;
   }
 
-  Integer omp_p = omp_get_max_threads();
+  Integer omp_p = SCTL_GET_MAX_THREADS();
 #pragma omp parallel for schedule(static)
   for (Integer tid = 0; tid < omp_p; tid++) {
     Long a = d1 * (tid + 0) / omp_p;

--- a/include/sctl/mem_mgr.txx
+++ b/include/sctl/mem_mgr.txx
@@ -1,7 +1,6 @@
 #ifndef _SCTL_MEM_MGR_TXX_
 #define _SCTL_MEM_MGR_TXX_
 
-#include <omp.h>                // for omp_get_wtime
 #include <stdlib.h>             // for free, malloc
 #include <algorithm>            // for max
 #include <cassert>              // for assert
@@ -362,10 +361,10 @@ inline void MemoryManager::test() {
     for (Integer j = 0; j < 3; j++) {
       tmp = (Iterator<double>)memgr.malloc(M * sizeof(double));
       SCTL_ASSERT(tmp != NullIterator<double>());
-      tt = omp_get_wtime();
+      tt = SCTL_GET_WTIME();
 #pragma omp parallel for
       for (Long i = 0; i < M; i += 64) tmp[i] = (double)i;
-      tt = omp_get_wtime() - tt;
+      tt = SCTL_GET_WTIME() - tt;
       std::cout << tt << ' ';
       memgr.free((Iterator<char>)tmp);
     }
@@ -379,10 +378,10 @@ inline void MemoryManager::test() {
     for (Integer j = 0; j < 3; j++) {
       tmp = (double*)::malloc(M * sizeof(double));
       SCTL_ASSERT(tmp != nullptr);
-      tt = omp_get_wtime();
+      tt = SCTL_GET_WTIME();
 #pragma omp parallel for
       for (Long i = 0; i < M; i += 64) tmp[i] = (double)i;
-      tt = omp_get_wtime() - tt;
+      tt = SCTL_GET_WTIME() - tt;
       std::cout << tt << ' ';
       ::free(tmp);
     }

--- a/include/sctl/ompUtils.txx
+++ b/include/sctl/ompUtils.txx
@@ -1,7 +1,6 @@
 #ifndef _SCTL_OMPUTILS_TXX_
 #define _SCTL_OMPUTILS_TXX_
 
-#include <omp.h>              // for omp_get_max_threads
 #include <algorithm>          // for lower_bound, sort, merge
 #include <functional>         // for less
 #include <iterator>           // for iterator_traits
@@ -95,7 +94,7 @@ template <class T, class StrictWeakOrdering> inline void omp_par::merge_sort(T A
   typedef typename std::iterator_traits<T>::difference_type _DiffType;
   typedef typename std::iterator_traits<T>::value_type _ValType;
 
-  int p = omp_get_max_threads();
+  int p = SCTL_GET_MAX_THREADS();
   _DiffType N = A_last - A;
   if (N < 2 * p) {
     std::sort(A, A_last, comp);
@@ -159,7 +158,7 @@ template <class ConstIter, class Int> typename std::iterator_traits<ConstIter>::
 template <class ConstIter, class Iter, class Int> void omp_par::scan(ConstIter A, Iter B, Int cnt) {
   typedef typename std::iterator_traits<Iter>::value_type ValueType;
 
-  Integer p = omp_get_max_threads();
+  Integer p = SCTL_GET_MAX_THREADS();
   if (cnt < (Int)100 * p) {
     for (Int i = 1; i < cnt; i++) B[i] = B[i - 1] + A[i - 1];
     return;

--- a/include/sctl/profile.txx
+++ b/include/sctl/profile.txx
@@ -2,7 +2,6 @@
 #define _SCTL_PROFILE_TXX_
 
 #include <sstream>            // for stringstream
-#include <omp.h>              // for omp_get_wtime
 #include <stdio.h>            // for size_t, snprintf
 #include <algorithm>          // for max
 #include <array>              // for array
@@ -15,7 +14,7 @@
 #include <string>             // for basic_string, allocator, char_traits
 #include <vector>             // for vector
 
-#include "sctl/common.hpp"    // for Long, SCTL_ASSERT, Integer, SCTL_ASSERT...
+#include "sctl/common.hpp"    // for Long, SCTL_ASSERT, Integer, SCTL_ASSERT, SCTL_GET_WTIME...
 #include "sctl/profile.hpp"   // for Profile, ProfileCounter, operator*, ope...
 #include "sctl/comm.hpp"      // for CommOp, Comm
 #include "sctl/comm.txx"      // for Comm::Rank, Comm::Size, Comm::Allreduce  // TODO: remove circular include (profile.txx -> comm.txx -> vector.txx -> profile.txx)
@@ -252,7 +251,7 @@ namespace sctl {
     std::array<std::atomic<Long>, Nfield> counters;
     std::map<std::string, ProfExpr> prof_fields;
 
-    inline ProfileData() : t0(omp_get_wtime()), enable_state(false) {
+    inline ProfileData() : t0(SCTL_GET_WTIME()), enable_state(false) {
       constexpr double gb_scale = (1./1024/1024/1024);
       for (auto& x : counters) x = 0;
 
@@ -484,7 +483,7 @@ namespace sctl {
 
       prof.e_log.push_back(true);
       prof.n_log.push_back(prof.name.top());
-      prof.counters[(Long)ProfileCounter::TIME].store((Long)((omp_get_wtime()-prof.t0)*1e9),std::memory_order_relaxed);
+      prof.counters[(Long)ProfileCounter::TIME].store((Long)((SCTL_GET_WTIME()-prof.t0)*1e9),std::memory_order_relaxed);
       for (Long i = 0; i < Nfield; i++) prof.counter_log.push_back(prof.counters[i]);
     }
   }
@@ -504,7 +503,7 @@ namespace sctl {
 
       prof.e_log.push_back(false);
       prof.n_log.push_back(name_);
-      prof.counters[(Long)ProfileCounter::TIME].store((Long)((omp_get_wtime()-prof.t0)*1e9),std::memory_order_relaxed);
+      prof.counters[(Long)ProfileCounter::TIME].store((Long)((SCTL_GET_WTIME()-prof.t0)*1e9),std::memory_order_relaxed);
       for (Long i = 0; i < Nfield; i++) prof.counter_log.push_back(prof.counters[i]);
 
   #ifndef NDEBUG

--- a/include/sctl/sph_harm.txx
+++ b/include/sctl/sph_harm.txx
@@ -3,7 +3,6 @@
 
 #include <fstream>               // for ofstream
 #include <sstream>               // for stringstream
-#include <omp.h>                  // for omp_get_num_threads, omp_get_thread...
 #include <stdlib.h>               // for drand48
 #include <algorithm>              // for min, max
 #include <cassert>                // for assert
@@ -379,8 +378,8 @@ template <class Real> void SphericalHarmonics<Real>::SHC2Pole(const Vector<Real>
   if (arrange == SHCArrange::ALL) {
     #pragma omp parallel
     { // Compute pole
-      Integer tid = omp_get_thread_num();
-      Integer omp_p = omp_get_num_threads();
+      Integer tid = SCTL_GET_THREAD_NUM();
+      Integer omp_p = SCTL_GET_NUM_THREADS();
 
       Long a = (tid + 0) * N / omp_p;
       Long b = (tid + 1) * N / omp_p;
@@ -398,8 +397,8 @@ template <class Real> void SphericalHarmonics<Real>::SHC2Pole(const Vector<Real>
   if (arrange == SHCArrange::ROW_MAJOR) {
     #pragma omp parallel
     { // Compute pole
-      Integer tid = omp_get_thread_num();
-      Integer omp_p = omp_get_num_threads();
+      Integer tid = SCTL_GET_THREAD_NUM();
+      Integer omp_p = SCTL_GET_NUM_THREADS();
 
       Long a = (tid + 0) * N / omp_p;
       Long b = (tid + 1) * N / omp_p;
@@ -419,8 +418,8 @@ template <class Real> void SphericalHarmonics<Real>::SHC2Pole(const Vector<Real>
   if (arrange == SHCArrange::COL_MAJOR_NONZERO) {
     #pragma omp parallel
     { // Compute pole
-      Integer tid = omp_get_thread_num();
-      Integer omp_p = omp_get_num_threads();
+      Integer tid = SCTL_GET_THREAD_NUM();
+      Integer omp_p = SCTL_GET_NUM_THREADS();
 
       Long a = (tid + 0) * N / omp_p;
       Long b = (tid + 1) * N / omp_p;
@@ -2200,8 +2199,8 @@ template <class Real> void SphericalHarmonics<Real>::Grid2SHC_(const Vector<Real
   Vector<Real> B0(B0_storage);
   #pragma omp parallel
   { // B0 <-- Transpose(FFT(X))
-    Integer tid=omp_get_thread_num();
-    Integer omp_p=omp_get_num_threads();
+    Integer tid=SCTL_GET_THREAD_NUM();
+    Integer omp_p=SCTL_GET_NUM_THREADS();
     Long a=(tid+0)*N*Nt/omp_p;
     Long b=(tid+1)*N*Nt/omp_p;
 
@@ -2226,8 +2225,8 @@ template <class Real> void SphericalHarmonics<Real>::Grid2SHC_(const Vector<Real
   if (B1.Dim() != N*(p1+1)*(p1+1)) B1.ReInit(N*(p1+1)*(p1+1));
   #pragma omp parallel
   { // Evaluate Legendre polynomial
-    Integer tid=omp_get_thread_num();
-    Integer omp_p=omp_get_num_threads();
+    Integer tid=SCTL_GET_THREAD_NUM();
+    Integer omp_p=SCTL_GET_NUM_THREADS();
 
     Long offset0=0;
     Long offset1=0;
@@ -2261,8 +2260,8 @@ template <class Real> void SphericalHarmonics<Real>::SHCArrange0(const Vector<Re
     if(S.Dim() != N * M) S.ReInit(N * M);
     #pragma omp parallel
     { // S <-- Rearrange(B1)
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long a=(tid+0)*N/omp_p;
       Long b=(tid+1)*N/omp_p;
@@ -2294,8 +2293,8 @@ template <class Real> void SphericalHarmonics<Real>::SHCArrange0(const Vector<Re
     if(S.Dim() != N * M) S.ReInit(N * M);
     #pragma omp parallel
     { // S <-- Rearrange(B1)
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long a=(tid+0)*N/omp_p;
       Long b=(tid+1)*N/omp_p;
@@ -2327,8 +2326,8 @@ template <class Real> void SphericalHarmonics<Real>::SHCArrange0(const Vector<Re
     if(S.Dim() != N * M) S.ReInit(N * M);
     #pragma omp parallel
     { // S <-- Rearrange(B1)
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long a=(tid+0)*N/omp_p;
       Long b=(tid+1)*N/omp_p;
@@ -2370,8 +2369,8 @@ template <class Real> void SphericalHarmonics<Real>::SHCArrange1(const Vector<Re
   if (arrange == SHCArrange::ALL) { // B0 <-- Rearrange(S)
     #pragma omp parallel
     { // B0 <-- Rearrange(S)
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long a=(tid+0)*N/omp_p;
       Long b=(tid+1)*N/omp_p;
@@ -2398,8 +2397,8 @@ template <class Real> void SphericalHarmonics<Real>::SHCArrange1(const Vector<Re
   if (arrange == SHCArrange::ROW_MAJOR) { // B0 <-- Rearrange(S)
     #pragma omp parallel
     { // B0 <-- Rearrange(S)
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long a=(tid+0)*N/omp_p;
       Long b=(tid+1)*N/omp_p;
@@ -2426,8 +2425,8 @@ template <class Real> void SphericalHarmonics<Real>::SHCArrange1(const Vector<Re
   if (arrange == SHCArrange::COL_MAJOR_NONZERO) { // B0 <-- Rearrange(S)
     #pragma omp parallel
     { // B0 <-- Rearrange(S)
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long a=(tid+0)*N/omp_p;
       Long b=(tid+1)*N/omp_p;
@@ -2473,8 +2472,8 @@ template <class Real> void SphericalHarmonics<Real>::SHC2Grid_(const Vector<Real
   if(X || X_phi){
     #pragma omp parallel
     { // Evaluate Legendre polynomial
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long offset0=0;
       Long offset1=0;
@@ -2499,8 +2498,8 @@ template <class Real> void SphericalHarmonics<Real>::SHC2Grid_(const Vector<Real
 
     #pragma omp parallel
     { // Transpose and evaluate Fourier
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long a=(tid+0)*N*Nt/omp_p;
       Long b=(tid+1)*N*Nt/omp_p;
@@ -2546,8 +2545,8 @@ template <class Real> void SphericalHarmonics<Real>::SHC2Grid_(const Vector<Real
   if(X_theta){
     #pragma omp parallel
     { // Evaluate Legendre gradient
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long offset0=0;
       Long offset1=0;
@@ -2572,8 +2571,8 @@ template <class Real> void SphericalHarmonics<Real>::SHC2Grid_(const Vector<Real
 
     #pragma omp parallel
     { // Transpose and evaluate Fourier
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long a=(tid+0)*N*Nt/omp_p;
       Long b=(tid+1)*N*Nt/omp_p;
@@ -3205,8 +3204,8 @@ template <class Real> void SphericalHarmonics<Real>::SHC2GridTranspose(const Vec
 
   #pragma omp parallel
   { // Evaluate Fourier and transpose
-    Integer tid=omp_get_thread_num();
-    Integer omp_p=omp_get_num_threads();
+    Integer tid=SCTL_GET_THREAD_NUM();
+    Integer omp_p=SCTL_GET_NUM_THREADS();
 
     Long a=(tid+0)*N*(p0+1)/omp_p;
     Long b=(tid+1)*N*(p0+1)/omp_p;
@@ -3230,8 +3229,8 @@ template <class Real> void SphericalHarmonics<Real>::SHC2GridTranspose(const Vec
 
   #pragma omp parallel
   { // Evaluate Legendre polynomial
-    Integer tid=omp_get_thread_num();
-    Integer omp_p=omp_get_num_threads();
+    Integer tid=SCTL_GET_THREAD_NUM();
+    Integer omp_p=SCTL_GET_NUM_THREADS();
 
     Long offset0=0;
     Long offset1=0;
@@ -3256,8 +3255,8 @@ template <class Real> void SphericalHarmonics<Real>::SHC2GridTranspose(const Vec
 
   #pragma omp parallel
   { // S <-- Rearrange(B0)
-    Integer tid=omp_get_thread_num();
-    Integer omp_p=omp_get_num_threads();
+    Integer tid=SCTL_GET_THREAD_NUM();
+    Integer omp_p=SCTL_GET_NUM_THREADS();
 
     Long a=(tid+0)*N/omp_p;
     Long b=(tid+1)*N/omp_p;
@@ -3298,8 +3297,8 @@ template <class Real> void SphericalHarmonics<Real>::RotateAll(const Vector<Real
 
   #pragma omp parallel
   { // Construct all p0*(p0+1) rotations
-    Integer tid=omp_get_thread_num();
-    Integer omp_p=omp_get_num_threads();
+    Integer tid=SCTL_GET_THREAD_NUM();
+    Integer omp_p=SCTL_GET_NUM_THREADS();
     Matrix<Real> B0(dof*p0,Ncoef); // memory buffer
 
     std::vector<Matrix<Real>> Bi(p0+1), Bo(p0+1); // memory buffers
@@ -3387,8 +3386,8 @@ template <class Real> void SphericalHarmonics<Real>::RotateTranspose(const Vecto
 
   #pragma omp parallel
   { // Transpose all p0*(p0+1) rotations
-    Integer tid=omp_get_thread_num();
-    Integer omp_p=omp_get_num_threads();
+    Integer tid=SCTL_GET_THREAD_NUM();
+    Integer omp_p=SCTL_GET_NUM_THREADS();
     Matrix<Real> B0(dof*p0,Ncoef); // memory buffer
 
     std::vector<Matrix<Real>> Bi(p0+1), Bo(p0+1); // memory buffers
@@ -3461,7 +3460,7 @@ template <class Real> void SphericalHarmonics<Real>::StokesSingularInteg(const V
   if(DLMatrix) DLMatrix->ReInit(Nves*(Ncoef*COORD_DIM)*(Ncoef*COORD_DIM));
 
   Long BLOCK_SIZE=(Long)6e9/((3*2*p1*(p1+1))*(3*2*p0*(p0+1))*2*8); // Limit memory usage to 6GB
-  BLOCK_SIZE=std::min<Long>(BLOCK_SIZE,omp_get_max_threads());
+  BLOCK_SIZE=std::min<Long>(BLOCK_SIZE,SCTL_GET_MAX_THREADS());
   BLOCK_SIZE=std::max<Long>(BLOCK_SIZE,1);
 
   for(Long a=0;a<Nves;a+=BLOCK_SIZE){
@@ -3512,8 +3511,8 @@ template <class Real> template <bool SLayer, bool DLayer> void SphericalHarmonic
 
     #pragma omp parallel
     {
-      Integer tid=omp_get_thread_num();
-      Integer omp_p=omp_get_num_threads();
+      Integer tid=SCTL_GET_THREAD_NUM();
+      Integer omp_p=SCTL_GET_NUM_THREADS();
 
       Long a=(tid+0)*N/omp_p;
       Long b=(tid+1)*N/omp_p;
@@ -3621,8 +3620,8 @@ template <class Real> template <bool SLayer, bool DLayer> void SphericalHarmonic
       SL3.ReInit(N*COORD_DIM*Ncoef*COORD_DIM*Ngrid);
       #pragma omp parallel
       {
-        Integer tid=omp_get_thread_num();
-        Integer omp_p=omp_get_num_threads();
+        Integer tid=SCTL_GET_THREAD_NUM();
+        Integer omp_p=SCTL_GET_NUM_THREADS();
         ScratchBuf<Real> B_storage(COORD_DIM*Ncoef * Ngrid*COORD_DIM);
         Matrix<Real> B(COORD_DIM*Ncoef, Ngrid*COORD_DIM, B_storage.begin(), false);
 
@@ -3660,8 +3659,8 @@ template <class Real> template <bool SLayer, bool DLayer> void SphericalHarmonic
       DL3.ReInit(N*COORD_DIM*Ncoef*COORD_DIM*Ngrid);
       #pragma omp parallel
       {
-        Integer tid=omp_get_thread_num();
-        Integer omp_p=omp_get_num_threads();
+        Integer tid=SCTL_GET_THREAD_NUM();
+        Integer omp_p=SCTL_GET_NUM_THREADS();
         ScratchBuf<Real> B_storage(COORD_DIM*Ncoef * Ngrid*COORD_DIM);
         Matrix<Real> B(COORD_DIM*Ncoef, Ngrid*COORD_DIM, B_storage.begin(), false);
 


### PR DESCRIPTION
I've wrapped all `omp_*` calls with `SCTL_*` macro calls of the same name in `common.hpp`. This allows for builds with openmp disabled, which is useful on mac, and when trying to get reasonable stack traces for profiling.