### PR TITLE
morton: per-axis periodicity + wide-path/UB fixes

### DIFF
--- a/include/sctl/boundary_integral.txx
+++ b/include/sctl/boundary_integral.txx
@@ -207,7 +207,7 @@ namespace sctl {
       Vector<Morton<COORD_DIM>> nbr_lst; // tmp
       for (Long i = 0; i < src_nodes0.Dim(); i++) {
         user_proc_set.clear();
-        src_nodes0[i].mid.NbrList(nbr_lst, src_nodes0[i].mid.Depth(), false);
+        src_nodes0[i].mid.NbrList(nbr_lst, src_nodes0[i].mid.Depth(), Periodicity::NONE);
         for (const auto nbr : nbr_lst) if (nbr.Depth() != Morton<COORD_DIM>::INVALID_DEPTH) {
           const auto proc_split_srch = [&splitter_nodes,&comp_node_mid](const Morton<COORD_DIM>& m) {
             NodeData srch_node; srch_node.mid = m;
@@ -310,7 +310,7 @@ namespace sctl {
           { // build trg_mid_lst, trg_range
             Morton<COORD_DIM> nxt_node;
             for (const auto& src_mid : src_mid_lst) {
-              src_mid.NbrList(nbr_lst, src_mid.Depth(), false);
+              src_mid.NbrList(nbr_lst, src_mid.Depth(), Periodicity::NONE);
               for (const auto& mid : nbr_lst) if (mid.Depth() != Morton<COORD_DIM>::INVALID_DEPTH) {
                 trg_mid_set.insert(mid);
               }
@@ -333,7 +333,7 @@ namespace sctl {
           }
           { // build interaction list trg_src_near_mid
             for (Long i = 0; i < src_mid_lst.Dim(); i++) {
-              src_mid_lst[i].NbrList(nbr_lst, src_mid_lst[i].Depth(), false);
+              src_mid_lst[i].NbrList(nbr_lst, src_mid_lst[i].Depth(), Periodicity::NONE);
               for (const auto& mid : nbr_lst) if (mid.Depth() != Morton<COORD_DIM>::INVALID_DEPTH) {
                 Long j = std::upper_bound(trg_mid_lst.begin(), trg_mid_lst.end(), mid) - trg_mid_lst.begin() - 1;
                 if (j>=0 && mid.Ancestor(trg_mid_lst[j].Depth()) == trg_mid_lst[j]) {
@@ -903,7 +903,7 @@ namespace sctl {
         Long count = 1;
         periodic_shift = 0;
         for (Long k = 0; k < COORD_DIM; k++) {
-          if (static_cast<uint8_t>(periodicity_)&(1<<k)) {
+          if (is_periodic(periodicity_, k)) {
             for (Long i = count; i < 3*count; i++) {
               for (Long kk = 0; kk < k; kk++) periodic_shift[i][kk] = periodic_shift[i%count][kk];
               periodic_shift[i][k] = (i/count==2 ? -1 : i/count);

--- a/include/sctl/boundary_quadrature.hpp
+++ b/include/sctl/boundary_quadrature.hpp
@@ -941,7 +941,7 @@ template <class Real> class Quadrature {
 
               Vector<std::set<Long>> near_elem(Trg.Dim());
               for (Integer d = 0; d <= d0; d++) {
-                trg_mid.NbrList(nbr_mid_tmp, d, period_length>0);
+                trg_mid.NbrList(nbr_mid_tmp, d, period_length>0 ? all_periodic(CoordDim) : Periodicity::NONE);
                 for (const auto& src_mid : nbr_mid_tmp) if (src_mid.Depth() != Morton<CoordDim>::INVALID_DEPTH) { // Set Src
                   PtData m0, m1;
                   m0.mid = src_mid;

--- a/include/sctl/common.hpp
+++ b/include/sctl/common.hpp
@@ -1,10 +1,11 @@
 #ifndef _SCTL_COMMON_HPP_
 #define _SCTL_COMMON_HPP_
 
-#include <stdio.h>   // for NULL, stderr
-#include <stdlib.h>  // for abort
-#include <cstdint>   // for int64_t
-#include <iostream>  // for char_traits, basic_ostream, operator<<, cerr
+#include <stdio.h>      // for NULL, stderr
+#include <stdlib.h>     // for abort
+#include <cstdint>      // for int64_t
+#include <iostream>     // for char_traits, basic_ostream, operator<<, cerr
+#include <type_traits>  // for underlying_type_t (Periodicity helpers)
 
 #ifndef SCTL_DATA_PATH
 #  define SCTL_DATA_PATH ./data/
@@ -55,6 +56,34 @@
 namespace sctl {
 typedef long Integer;  // bounded numbers < 32k
 typedef int64_t Long;  // problem size
+
+// Per-axis periodicity bitmask (bit d = axis d). Widen the underlying type for more than 8 axes.
+enum class Periodicity : uint8_t {
+  NONE = 0,
+  X = 1u << 0,
+  Y = 1u << 1,
+  Z = 1u << 2,
+  XY = X | Y,
+  XYZ = X | Y | Z
+};
+
+using PeriodicityT = std::underlying_type_t<Periodicity>;
+constexpr Integer PERIODICITY_MAX_DIM = static_cast<Integer>(sizeof(PeriodicityT) * 8);
+
+constexpr Periodicity operator|(Periodicity a, Periodicity b) {
+  return static_cast<Periodicity>(static_cast<PeriodicityT>(a) | static_cast<PeriodicityT>(b));
+}
+
+// True iff axis dim is periodic in p.
+constexpr bool is_periodic(Periodicity p, Integer dim) {
+  return ((static_cast<PeriodicityT>(p) >> dim) & PeriodicityT(1)) != 0;
+}
+
+// Mask with axes 0..dim-1 periodic.
+constexpr Periodicity all_periodic(Integer dim) {
+  return static_cast<Periodicity>(dim >= PERIODICITY_MAX_DIM ? static_cast<PeriodicityT>(~PeriodicityT(0))
+                                                             : static_cast<PeriodicityT>((PeriodicityT(1) << dim) - 1));
+}
 }
 
 #define SCTL_WARN(msg)                                         \

--- a/include/sctl/fmm-wrapper.hpp
+++ b/include/sctl/fmm-wrapper.hpp
@@ -28,18 +28,6 @@ namespace pvfmm {
 namespace sctl {
 
 /**
- * Enum for periodicity in each coordinate direction.
- */
-enum class Periodicity : uint8_t {
-  NONE = 0,
-  X = 1u << 0,
-  Y = 1u << 1,
-  Z = 1u << 2,
-  XY = X | Y,
-  XYZ = X | Y | Z
-};
-
-/**
  * Evaluate potentials from particle sources using PVFMM when available, otherwise, use direct
  * computation.  To enable PVFMM, the macro `SCTL_HAVE_PVFMM` must be defined, the code must be
  * compiled with MPI and linked to PVFMM.

--- a/include/sctl/morton.hpp
+++ b/include/sctl/morton.hpp
@@ -204,17 +204,14 @@ template <Integer DIM> class Morton {
   SCTL_GPU_HD std::array<Morton, (1 << DIM)> Children() const;
 
   /**
-   * `3^DIM` same-level neighbors of the node containing `*this` (ancestor truncated to `level`).
-   * Indexing: for offset `(δ_0, …, δ_{DIM-1})` with `δ_d ∈ {-1, 0, +1}`, the neighbor sits at
-   * `Σ ( (δ_d + 1) * 3^d )`. Self is at the centre index `(3^DIM - 1)/2`.
-   *
-   * Non-periodic out-of-bounds entries are flagged with `depth = INVALID_DEPTH` (0xFF).
-   * Periodic wraps mod `1 << level`.
+   * `3^DIM` same-level neighbors (ancestor truncated to `level`). The neighbor for offset
+   * `(δ_0,…,δ_{DIM-1})`, `δ_d ∈ {-1,0,+1}`, is at index `Σ (δ_d + 1) 3^d`; self is the centre.
+   * Periodic axes wrap; non-periodic out-of-domain neighbors get `depth = INVALID_DEPTH`.
    */
-  SCTL_GPU_HD std::array<Morton, pow<DIM, std::size_t>(3)> NbrList(uint8_t level, bool periodic) const;
+  SCTL_GPU_HD std::array<Morton, pow<DIM, std::size_t>(3)> NbrList(uint8_t level, Periodicity periodicity) const;
 
   /** sctl::Tree-compat overloads: write into a Vector outparam (host-only). */
-  void NbrList(Vector<Morton>& nlst, uint8_t level, bool periodic) const;
+  void NbrList(Vector<Morton>& nlst, uint8_t level, Periodicity periodicity) const;
   void Children(Vector<Morton>& nlst) const;
 
   /** Lexicographic Morton order: by code first, with `depth` as tiebreaker. */

--- a/include/sctl/morton.txx
+++ b/include/sctl/morton.txx
@@ -62,25 +62,25 @@ template <Integer DIM> template <int NWORDS_> constexpr bool MortonCode<DIM>::Mo
 }
 
 template <Integer DIM> template <int NWORDS_> constexpr typename MortonCode<DIM>::template MortonBig<NWORDS_> MortonCode<DIM>::MortonBig<NWORDS_>::operator|(const MortonBig& o) const {
-  MortonBig r;
+  MortonBig r{};
   for (int i = 0; i < NWORDS_; ++i) r.w[i] = w[i] | o.w[i];
   return r;
 }
 
 template <Integer DIM> template <int NWORDS_> constexpr typename MortonCode<DIM>::template MortonBig<NWORDS_> MortonCode<DIM>::MortonBig<NWORDS_>::operator&(const MortonBig& o) const {
-  MortonBig r;
+  MortonBig r{};
   for (int i = 0; i < NWORDS_; ++i) r.w[i] = w[i] & o.w[i];
   return r;
 }
 
 template <Integer DIM> template <int NWORDS_> constexpr typename MortonCode<DIM>::template MortonBig<NWORDS_> MortonCode<DIM>::MortonBig<NWORDS_>::operator^(const MortonBig& o) const {
-  MortonBig r;
+  MortonBig r{};
   for (int i = 0; i < NWORDS_; ++i) r.w[i] = w[i] ^ o.w[i];
   return r;
 }
 
 template <Integer DIM> template <int NWORDS_> constexpr typename MortonCode<DIM>::template MortonBig<NWORDS_> MortonCode<DIM>::MortonBig<NWORDS_>::operator+(const MortonBig& o) const {
-  MortonBig r;
+  MortonBig r{};
   std::uint64_t carry = 0;
   for (int i = 0; i < NWORDS_; ++i) {
     const std::uint64_t s1 = w[i] + o.w[i];
@@ -99,7 +99,7 @@ template <Integer DIM> template <int NWORDS_> constexpr typename MortonCode<DIM>
 }
 
 template <Integer DIM> template <int NWORDS_> constexpr typename MortonCode<DIM>::template MortonBig<NWORDS_> MortonCode<DIM>::MortonBig<NWORDS_>::operator<<(int s) const {
-  MortonBig r;
+  MortonBig r{};
   const int ws = s / 64, bs = s % 64;
   for (int i = NWORDS_ - 1; i >= 0; --i) {
     std::uint64_t v = 0;
@@ -111,7 +111,7 @@ template <Integer DIM> template <int NWORDS_> constexpr typename MortonCode<DIM>
 }
 
 template <Integer DIM> template <int NWORDS_> constexpr typename MortonCode<DIM>::template MortonBig<NWORDS_> MortonCode<DIM>::MortonBig<NWORDS_>::operator>>(int s) const {
-  MortonBig r;
+  MortonBig r{};
   const int ws = s / 64, bs = s % 64;
   for (int i = 0; i < NWORDS_; ++i) {
     std::uint64_t v = 0;
@@ -223,7 +223,7 @@ template <Integer DIM> SCTL_GPU_HD std::uint64_t MortonCode<DIM>::compact_bits(M
   MortonInteger r = (code >> static_cast<int>(d)) & initial_mask;
   r = compact_step<0>(r);
   // The compacted xi occupies the low MAX_DEPTH bits; safe to cast to uint64_t (MAX_DEPTH < 64).
-  if constexpr (TOTAL_BITS <= 64) {
+  if constexpr (STORAGE_BITS <= 64) {
     return static_cast<std::uint64_t>(r);
   } else {
     return r.w[0];
@@ -328,32 +328,43 @@ template <Integer DIM> SCTL_GPU_HD std::array<Morton<DIM>, (1 << DIM)> Morton<DI
   return out;
 }
 
-template <Integer DIM> SCTL_GPU_HD std::array<Morton<DIM>, pow<DIM, std::size_t>(3)> Morton<DIM>::NbrList(uint8_t level, bool periodic) const {
+template <Integer DIM> SCTL_GPU_HD std::array<Morton<DIM>, pow<DIM, std::size_t>(3)> Morton<DIM>::NbrList(uint8_t level, Periodicity periodicity) const {
+  static_assert(DIM <= PERIODICITY_MAX_DIM, "NbrList: DIM exceeds the Periodicity bitmask width");
   using MI = typename MortonCode<DIM>::MortonInteger;
   std::array<Morton, pow<DIM, std::size_t>(3)> out{};
 
   // Step 1: truncate to `level` and extract per-coord ints.
   const Morton base = Ancestor(level);
-  std::int64_t xi_self[DIM];
+  std::uint64_t xi_self[DIM];
   for (Integer d = 0; d < DIM; ++d) {
-    xi_self[d] = static_cast<std::int64_t>(MortonCode<DIM>::compact_bits(base.mid.code, d));
+    xi_self[d] = MortonCode<DIM>::compact_bits(base.mid.code, d);
   }
-  const std::int64_t box_size = std::int64_t(1) << (MAX_DEPTH - level);
-  const std::int64_t maxCoord = std::int64_t(1) << MAX_DEPTH;
+  const std::uint64_t box_size = std::uint64_t(1) << (MAX_DEPTH - level);
+  const std::uint64_t maxCoord = std::uint64_t(1) << MAX_DEPTH;
 
   // Step 2: 3^DIM offset combos. idx = j_0 + 3*j_1 + 9*j_2 + ..., j_d ∈ {0,1,2} → offset (-1,0,+1)*box_size.
   for (Integer idx = 0; idx < pow<DIM, Integer>(3); ++idx) {
-    std::int64_t xi_nbr[DIM];
+    std::uint64_t xi_nbr[DIM];
     bool out_of_bounds = false;
     Integer tmp = idx;
     for (Integer d = 0; d < DIM; ++d) {
-      const std::int64_t offset = (static_cast<std::int64_t>(tmp % 3) - 1) * box_size;
+      const int j = static_cast<int>(tmp % 3) - 1;  // -1, 0, or +1
       tmp /= 3;
-      std::int64_t v = xi_self[d] + offset;
-      if (periodic) {
-        v = ((v % maxCoord) + maxCoord) % maxCoord;
-      } else if (v < 0 || v >= maxCoord) {
-        out_of_bounds = true;
+      const std::uint64_t self = xi_self[d];
+      std::uint64_t v = self;
+      if (j < 0) {
+        if (self < box_size) {
+          if (is_periodic(periodicity, d)) v = self + maxCoord - box_size;
+          else out_of_bounds = true;
+        } else {
+          v = self - box_size;
+        }
+      } else if (j > 0) {
+        v = self + box_size;
+        if (v >= maxCoord) {
+          if (is_periodic(periodicity, d)) v -= maxCoord;
+          else out_of_bounds = true;
+        }
       }
       xi_nbr[d] = v;
     }
@@ -362,7 +373,7 @@ template <Integer DIM> SCTL_GPU_HD std::array<Morton<DIM>, pow<DIM, std::size_t>
     } else {
       MI code = MI(0);
       for (Integer d = 0; d < DIM; ++d) {
-        code |= MortonCode<DIM>::spread_bits(static_cast<std::uint64_t>(xi_nbr[d])) << static_cast<int>(d);
+        code |= MortonCode<DIM>::spread_bits(xi_nbr[d]) << static_cast<int>(d);
       }
       out[idx] = Morton{MortonCode<DIM>(code), level};
     }
@@ -405,8 +416,8 @@ template <Integer DIM> SCTL_GPU_HD Long Morton<DIM>::operator-(const Morton& o) 
 }
 
 // sctl::Tree-compat overloads: write std::array result into a Vector outparam.
-template <Integer DIM> void Morton<DIM>::NbrList(Vector<Morton>& nlst, uint8_t level, bool periodic) const {
-  const auto arr = NbrList(level, periodic);
+template <Integer DIM> void Morton<DIM>::NbrList(Vector<Morton>& nlst, uint8_t level, Periodicity periodicity) const {
+  const auto arr = NbrList(level, periodicity);
   nlst.ReInit(static_cast<Long>(arr.size()));
   for (Long i = 0; i < static_cast<Long>(arr.size()); ++i) nlst[i] = arr[i];
 }

--- a/include/sctl/tree.hpp
+++ b/include/sctl/tree.hpp
@@ -92,12 +92,12 @@ template <Integer DIM> class Tree {
      * @param[in] coord Particle coordinates (in [0,1]^dim stored in AoS order) that describe the new tree refinement.
      * @param[in] M Maximum number of particles per tree node.
      * @param[in] balance21 Whether to do level-restriction (2:1 balance refinement).
-     * @param[in] periodic Whether the tree is periodic across the faces of the cube.
+     * @param[in] periodicity Per-axis periodicity bitmask (e.g. `Periodicity::X | Periodicity::Y`, or `all_periodic(DIM)`).
      * @param[in] halo_size 2^halo_size neighboring boxes will be included in the halo region. Default value of -1 means no halo region.
      *
      * @note This is a collective operation and must be called from all processes in the communicator.
      */
-    template <class Real> void UpdateRefinement(const Vector<Real>& coord, Long M = 1, bool balance21 = 0, bool periodic = 0, Integer halo_size = -1);
+    template <class Real> void UpdateRefinement(const Vector<Real>& coord, Long M = 1, bool balance21 = 0, Periodicity periodicity = Periodicity::NONE, Integer halo_size = -1);
 
     /**
      * Add named data to the tree nodes.
@@ -222,12 +222,12 @@ template <class Real, Integer DIM, class BaseTree = Tree<DIM>> class PtTree : pu
      * @param M Maximum number of points per box for refinement.
      * @param balance21 Flag indicating whether to construct a level-restricted
      *        tree with neighboring boxes within one level of each other.
-     * @param periodic Flag indicating periodic boundary conditions.
+     * @param periodicity Per-axis periodicity bitmask (e.g. `Periodicity::X | Periodicity::Y`, or `all_periodic(DIM)`).
      * @param[in] halo_size 2^halo_size neighboring boxes will be included in the halo region
      *
      * @note This is a collective operation and must be called from all processes in the communicator.
      */
-    void UpdateRefinement(const Vector<Real>& coord, Long M = 1, bool balance21 = 0, bool periodic = 0, Integer halo_size = -1);
+    void UpdateRefinement(const Vector<Real>& coord, Long M = 1, bool balance21 = 0, Periodicity periodicity = Periodicity::NONE, Integer halo_size = -1);
 
     /**
      * Add particles to the point tree.

--- a/include/sctl/tree.txx
+++ b/include/sctl/tree.txx
@@ -135,7 +135,7 @@ namespace sctl {
     return comm;
   }
 
-  template <Integer DIM> template <class Real> void Tree<DIM>::UpdateRefinement(const Vector<Real>& coord, Long M, bool balance21, bool periodic, Integer halo_size) {
+  template <Integer DIM> template <class Real> void Tree<DIM>::UpdateRefinement(const Vector<Real>& coord, Long M, bool balance21, Periodicity periodicity, Integer halo_size) {
     const Integer np = comm.Size();
     const Integer rank = comm.Rank();
 
@@ -308,7 +308,7 @@ namespace sctl {
         }
         for (Integer d = Morton<DIM>::MAX_DEPTH; d >= 0; d--) {
           for (const auto& m : parent_mid_set[d]) {
-            m.NbrList(nlst, d, periodic);
+            m.NbrList(nlst, d, periodicity);
             for (const auto& nbr : nlst) if (nbr.Depth() != Morton<DIM>::INVALID_DEPTH && nbr.Depth() > 0) parent_mid_set[d-1].insert(nbr.Ancestor(d-1));
             const Long idx = std::lower_bound(mins.begin(), mins.end(), m) - mins.begin();
             if (idx>=np || !m.isAncestor(mins[idx])) // exclude ancestors of all mins to reduce communication
@@ -369,7 +369,7 @@ namespace sctl {
         for (Long i = start_idx; i < end_idx; i++) {
           Morton<DIM> m0 = node_mid[i];
           Integer d0 = m0.Depth();
-          if (halo_size >= 0) m0.NbrList(nlst, std::max<Integer>(d0-halo_size,0), periodic);
+          if (halo_size >= 0) m0.NbrList(nlst, std::max<Integer>(d0-halo_size,0), periodicity);
           user_procs.clear();
           for (const auto& m : nlst) {
             if (m.Depth() != Morton<DIM>::INVALID_DEPTH) {
@@ -516,7 +516,7 @@ namespace sctl {
       { // Set neighbor list
         { // Set root neighbors
           const auto& n0 = node_mid[0];
-          const auto nlst = n0.NbrList(n0.Depth(), periodic);
+          const auto nlst = n0.NbrList(n0.Depth(), periodicity);
           static_assert(nlst.size() == MAX_NBRS);
           for (Long k = 0; k < MAX_NBRS; k++) {
             if (nlst[k].Depth() != Morton<DIM>::INVALID_DEPTH) node_lst[0].nbr[k] = 0;
@@ -530,12 +530,12 @@ namespace sctl {
           };
           static const auto nbr_path = []() {
             const auto parent = (Morton<DIM>{}).Children()[0].Children()[MAX_CHILD-1];
-            const auto parent_nbr_lst = parent.NbrList(parent.Depth(), false); // interior node, so periodicity doesn't matter
+            const auto parent_nbr_lst = parent.NbrList(parent.Depth(), Periodicity::NONE); // interior node, so periodicity doesn't matter
 
             Matrix<NbrPath> nbr_path(MAX_CHILD, MAX_NBRS);
             for (Integer p2n = 0; p2n < MAX_CHILD; p2n++) {
               const auto n0 = parent.Children()[p2n];
-              const auto nlst = n0.NbrList(n0.Depth(), false);
+              const auto nlst = n0.NbrList(n0.Depth(), Periodicity::NONE);
               for (Integer nbr_idx = 0; nbr_idx < MAX_NBRS; nbr_idx++) {
                 const auto& nbr = nlst[nbr_idx];
 
@@ -1043,9 +1043,9 @@ namespace sctl {
     #endif
   }
 
-  template <class Real, Integer DIM, class BaseTree> void PtTree<Real,DIM,BaseTree>::UpdateRefinement(const Vector<Real>& coord, Long M, bool balance21, bool periodic, Integer halo_size) {
+  template <class Real, Integer DIM, class BaseTree> void PtTree<Real,DIM,BaseTree>::UpdateRefinement(const Vector<Real>& coord, Long M, bool balance21, Periodicity periodicity, Integer halo_size) {
     const auto& comm = this->GetComm();
-    BaseTree::UpdateRefinement(coord, M, balance21, periodic, halo_size);
+    BaseTree::UpdateRefinement(coord, M, balance21, periodicity, halo_size);
 
     Long start_node_idx, end_node_idx;
     { // Set start_node_idx, end_node_idx

--- a/src/test-morton.cpp
+++ b/src/test-morton.cpp
@@ -214,7 +214,7 @@ int main() {
   {
     Morton root;
     sctl::Vector<Morton> nbrs;
-    root.NbrList(nbrs, /*level=*/0, /*periodic=*/true);
+    root.NbrList(nbrs, /*level=*/0, /*periodic=*/sctl::all_periodic(DIM));
     Long pow3 = 1;
     for (Integer d = 0; d < DIM; ++d) pow3 *= 3;
     CHECK(nbrs.Dim() == pow3);
@@ -222,7 +222,7 @@ int main() {
     for (Long i = 0; i < nbrs.Dim(); ++i) CHECK(nbrs[i] == root);
 
     sctl::Vector<Morton> nbrs2;
-    root.NbrList(nbrs2, 0, /*periodic=*/false);
+    root.NbrList(nbrs2, 0, /*periodic=*/sctl::Periodicity::NONE);
     CHECK(nbrs2.Dim() == pow3);
     // Non-periodic at root level 0: all off-axis offsets are out-of-bounds.
     // Only the self entry (at the centre index (3^DIM-1)/2) is valid.


### PR DESCRIPTION
Raise default SCTL_MAX_DEPTH 15->21, which surfaced three depth/DIM-dependent bugs in Morton/MortonCode (all fixed and regression-swept under UBSan/ASan):

- MortonBig operators value-initialize their result (`MortonBig r{}`), so the multi-word path is usable in constexpr under C++17 (operator<< is reached by the spread/compact mask lambdas).
- compact_bits picks the wide-vs-builtin branch on STORAGE_BITS, not TOTAL_BITS, fixing Morton<3> at MAX_DEPTH=21 (STORAGE_BITS=66>64 but TOTAL_BITS=63<=64).
- NbrList computes neighbor coords in uint64_t (was int64_t), removing signed-overflow UB at MAX_DEPTH=63 (2^63 > INT64_MAX); also ~2x faster on the periodic path (drops two modulos).

Add per-axis periodicity: Periodicity moves from fmm-wrapper.hpp to common.hpp and becomes a bitmask with is_periodic/all_periodic/operator| helpers derived from its underlying type (widen the enum's type for >8 axes). NbrList, Tree/PtTree::UpdateRefinement, and BoundaryIntegralOp now take a Periodicity instead of a bool, so periodicity can be set independently per axis.