### PR TITLE
FFT: const/non-const Execute overloads + alignment assert

### DIFF
--- a/include/sctl/fft_wrapper.hpp
+++ b/include/sctl/fft_wrapper.hpp
@@ -78,20 +78,32 @@ namespace sctl {
      * @param[in] dim_vec Dimensions of the input data.
      *
      * @param[in] Nthreads Number of threads (default is 1).
-     *
-     * @param[in] preserve_input If `false` (default), `Execute` may overwrite
-     * its input (only multi-D C2R does); set `true` to keep it intact.
      */
-    void Setup(FFT_Type fft_type, Long howmany, const Vector<Long>& dim_vec, Integer Nthreads = 1, bool preserve_input = false);
+    void Setup(FFT_Type fft_type, Long howmany, const Vector<Long>& dim_vec, Integer Nthreads = 1);
 
     /**
-     * Execute the FFT transform.
+     * Execute the transform, preserving `in` (multi-D C2R may cost a copy).
+     *
+     * @param[in] in the input data vector.
+     *
+     * @param[out] out the output data vector.
+     *
+     * @note FFTW build: `in`/`out` must match the plan's alignment
+     * (`SCTL_MEM_ALIGN`): a default `Vector` qualifies, a sub-view only if its
+     * offset preserves it.  Misaligned buffers trip an assert (else crash);
+     * the Cooley-Tukey fallback has none.
+     */
+    void Execute(const Vector<ValueType>& in, Vector<ValueType>& out) const;
+
+    /**
+     * Execute the transform; `in` MAY be overwritten (fast default). Pass
+     * `preserve_input = true` to keep it. Alignment rules as above.
      *
      * @param[in] in the input data vector.
      *
      * @param[out] out the output data vector.
      */
-    void Execute(const Vector<ValueType>& in, Vector<ValueType>& out) const;
+    void Execute(Vector<ValueType>& in, Vector<ValueType>& out, bool preserve_input = false) const;
 
     /**
      * Test the FFT implementation.
@@ -103,10 +115,14 @@ namespace sctl {
     /// Swap all state with `other`; backs the move operations.
     void Swap(FFT& other) noexcept;
 
-    //static void check_align(const Vector<ValueType>& in, const Vector<ValueType>& out);
+    /// Shared body; preserve_input keeps `in` (via plan_preserve or a scratch copy).
+    /// Not const-correct: writes `in` only when preserve_input==false, which only the
+    /// non-const Execute overload passes -- so the const_cast never mutates a const object.
+    void ExecuteImpl(const Vector<ValueType>& in, Vector<ValueType>& out, bool preserve_input) const;
 
-    FFTPlan<ValueType> plan;
-    bool copy_input;
+    FFTPlan<ValueType> plan;          // destroy-input plan (fast)
+    FFTPlan<ValueType> plan_preserve; // preserve-input plan; null for multi-D C2R
+    Integer align_in, align_out; // plan alignment; Execute asserts in/out match
 
     StaticArray<Long,2> dim; // operator dimensions
     FFT_Type fft_type; // type of FFT transform

--- a/include/sctl/fft_wrapper.txx
+++ b/include/sctl/fft_wrapper.txx
@@ -886,7 +886,7 @@ namespace sctl {
 
   template <class ValueType> FFT<ValueType>::~FFT() {}
 
-  template <class ValueType> FFT<ValueType>::FFT() : copy_input(false), dim{0,0}, fft_type(FFT_Type::R2C), howmany_(0) {}
+  template <class ValueType> FFT<ValueType>::FFT() : align_in(0), align_out(0), dim{0,0}, fft_type(FFT_Type::R2C), howmany_(0) {}
 
   // Move via swap: the moved-from object retains the target's previous plan, so
   // its (possibly type-specialized) destructor releases it. Works for both the
@@ -900,7 +900,9 @@ namespace sctl {
 
   template <class ValueType> void FFT<ValueType>::Swap(FFT<ValueType>& other) noexcept {
     std::swap(plan, other.plan);
-    std::swap(copy_input, other.copy_input);
+    std::swap(plan_preserve, other.plan_preserve);
+    std::swap(align_in, other.align_in);
+    std::swap(align_out, other.align_out);
     std::swap(dim[0], other.dim[0]);
     std::swap(dim[1], other.dim[1]);
     std::swap(fft_type, other.fft_type);
@@ -909,15 +911,18 @@ namespace sctl {
 
   template <class ValueType> Long FFT<ValueType>::Dim(Integer i) const { return dim[i]; }
 
-  template <class ValueType> void FFT<ValueType>::Setup(FFT_Type fft_type_, Long howmany_, const Vector<Long>& dim_vec, Integer Nthreads, bool preserve_input) {
-    SCTL_UNUSED(preserve_input); // CT fallback never destroys its input.
+  template <class ValueType> void FFT<ValueType>::Setup(FFT_Type fft_type_, Long howmany_, const Vector<Long>& dim_vec, Integer Nthreads) {
     this->fft_type = fft_type_;
     this->howmany_ = howmany_;
-    this->copy_input = false;
     fft_fallback_internal::CTSetup<ValueType>(plan, fft_type_, howmany_, dim_vec, Nthreads, this->dim[0], this->dim[1]);
   }
 
-  template <class ValueType> void FFT<ValueType>::Execute(const Vector<ValueType>& in, Vector<ValueType>& out) const {
+  // Forward to ExecuteImpl (only it is specialized for FFTW).
+  template <class ValueType> void FFT<ValueType>::Execute(const Vector<ValueType>& in, Vector<ValueType>& out) const { ExecuteImpl(in, out, true); }
+  template <class ValueType> void FFT<ValueType>::Execute(Vector<ValueType>& in, Vector<ValueType>& out, bool preserve_input) const { ExecuteImpl(in, out, preserve_input); }
+
+  template <class ValueType> void FFT<ValueType>::ExecuteImpl(const Vector<ValueType>& in, Vector<ValueType>& out, bool preserve_input) const {
+    SCTL_UNUSED(preserve_input); // CT fallback never overwrites its input.
     fft_fallback_internal::CTExecute<ValueType>(plan, fft_type, howmany_, dim[0], dim[1], in, out);
   }
 
@@ -942,13 +947,14 @@ namespace sctl {
 
   template <> inline FFT<double>::~FFT() {
     if (plan.fftwplan) fftw_destroy_plan(plan.fftwplan);
+    if (plan_preserve.fftwplan) fftw_destroy_plan(plan_preserve.fftwplan);
     plan.fftwplan = nullptr;
+    plan_preserve.fftwplan = nullptr;
   }
 
-  template <> inline void FFT<double>::Setup(FFT_Type fft_type_, Long howmany_, const Vector<Long>& dim_vec, Integer Nthreads, bool preserve_input) {
+  template <> inline void FFT<double>::Setup(FFT_Type fft_type_, Long howmany_, const Vector<Long>& dim_vec, Integer Nthreads) {
     fft_type = fft_type_;
     this->howmany_ = howmany_;
-    copy_input = false;
 
     Long rank = dim_vec.Dim();
     Vector<int> dim_vec_(rank);
@@ -982,65 +988,53 @@ namespace sctl {
     if (!N0 || !N1) return;
     Vector<double> in(N0), out(N1);
 
+    // destroy-input + preserve-input plans (latter null for multi-D C2R)
+    auto mkplan = [&](unsigned flags) -> fftw_plan {
+      if      (fft_type == FFT_Type::R2C)     return fftw_plan_many_dft_r2c(rank, &dim_vec_[0], this->howmany_, &in[0], nullptr, 1, N0 / this->howmany_, (fftw_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, flags);
+      else if (fft_type == FFT_Type::C2C)     return fftw_plan_many_dft    (rank, &dim_vec_[0], this->howmany_, (fftw_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftw_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_FORWARD, flags);
+      else if (fft_type == FFT_Type::C2C_INV) return fftw_plan_many_dft    (rank, &dim_vec_[0], this->howmany_, (fftw_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftw_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_BACKWARD, flags);
+      else                                    return fftw_plan_many_dft_c2r(rank, &dim_vec_[0], this->howmany_, (fftw_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, &out[0], nullptr, 1, N1 / this->howmany_, flags);
+    };
     #pragma omp critical(SCTL_FFTW_PLAN)
     {
     FFTWInitThreads(Nthreads);
     if (plan.fftwplan) fftw_destroy_plan(plan.fftwplan);
-    plan.fftwplan = nullptr;
-    if (preserve_input) { // Try a plan that preserves its input.
-      if (fft_type == FFT_Type::R2C) {
-        plan.fftwplan = fftw_plan_many_dft_r2c(rank, &dim_vec_[0], this->howmany_, &in[0], nullptr, 1, N0 / this->howmany_, (fftw_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      } else if (fft_type == FFT_Type::C2C) {
-        plan.fftwplan = fftw_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftw_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftw_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_FORWARD, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      } else if (fft_type == FFT_Type::C2C_INV) {
-        plan.fftwplan = fftw_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftw_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftw_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_BACKWARD, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      } else if (fft_type == FFT_Type::C2R) {
-        plan.fftwplan = fftw_plan_many_dft_c2r(rank, &dim_vec_[0], this->howmany_, (fftw_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, &out[0], nullptr, 1, N1 / this->howmany_, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      }
-      // Multi-dim C2R has no preserve-input plan: fall back to copying the input.
-      if (!plan.fftwplan) copy_input = true;
-    }
-    if (!plan.fftwplan) { // Build plan without FFTW_PRESERVE_INPUT (may destroy input).
-      if (fft_type == FFT_Type::R2C) {
-        plan.fftwplan = fftw_plan_many_dft_r2c(rank, &dim_vec_[0], this->howmany_, &in[0], nullptr, 1, N0 / this->howmany_, (fftw_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_ESTIMATE);
-      } else if (fft_type == FFT_Type::C2C) {
-        plan.fftwplan = fftw_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftw_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftw_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_FORWARD, FFTW_ESTIMATE);
-      } else if (fft_type == FFT_Type::C2C_INV) {
-        plan.fftwplan = fftw_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftw_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftw_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_BACKWARD, FFTW_ESTIMATE);
-      } else if (fft_type == FFT_Type::C2R) {
-        plan.fftwplan = fftw_plan_many_dft_c2r(rank, &dim_vec_[0], this->howmany_, (fftw_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, &out[0], nullptr, 1, N1 / this->howmany_, FFTW_ESTIMATE);
-      }
-    }
+    if (plan_preserve.fftwplan) fftw_destroy_plan(plan_preserve.fftwplan);
+    plan.fftwplan = mkplan(FFTW_ESTIMATE);
+    plan_preserve.fftwplan = mkplan(FFTW_ESTIMATE | FFTW_PRESERVE_INPUT); // null for multi-D C2R
     }
     SCTL_ASSERT(plan.fftwplan);
+    align_in  = fftw_alignment_of(&in[0]);  // for Execute's alignment assert
+    align_out = fftw_alignment_of(&out[0]);
   }
 
-  template <> inline void FFT<double>::Execute(const Vector<double>& in, Vector<double>& out) const {
+  template <> inline void FFT<double>::ExecuteImpl(const Vector<double>& in, Vector<double>& out, bool preserve_input) const {
     using ValueType = double;
     Long N0 = Dim(0);
     Long N1 = Dim(1);
     if (!N0 || !N1) return;
     SCTL_ASSERT_MSG(in.Dim() == N0, "FFT: Wrong input size.");
     if (out.Dim() != N1) out.ReInit(N1);
-    //check_align(in, out);
 
-    // Unnormalized (raw FFTW) transform: no scaling is applied.
-    auto exec = [this](ConstIterator<ValueType> ip, Vector<ValueType>& op) {
-      if      (fft_type == FFT_Type::R2C)     fftw_execute_dft_r2c(plan.fftwplan, (double*)&ip[0], (fftw_complex*)&op[0]);
-      else if (fft_type == FFT_Type::C2C)     fftw_execute_dft    (plan.fftwplan, (fftw_complex*)&ip[0], (fftw_complex*)&op[0]);
-      else if (fft_type == FFT_Type::C2C_INV) fftw_execute_dft    (plan.fftwplan, (fftw_complex*)&ip[0], (fftw_complex*)&op[0]);
-      else                                    fftw_execute_dft_c2r(plan.fftwplan, (fftw_complex*)&ip[0], (double*)&op[0]);
+    // raw FFTW (unnormalized)
+    auto exec = [this](fftw_plan pl, ConstIterator<ValueType> ip, Vector<ValueType>& op) {
+      SCTL_ASSERT_MSG(fftw_alignment_of((ValueType*)&ip[0]) == align_in,  "FFT: input not aligned to plan (see Execute docs).");
+      SCTL_ASSERT_MSG(fftw_alignment_of((ValueType*)&op[0]) == align_out, "FFT: output not aligned to plan (see Execute docs).");
+      if      (fft_type == FFT_Type::R2C)     fftw_execute_dft_r2c(pl, (double*)&ip[0], (fftw_complex*)&op[0]);
+      else if (fft_type == FFT_Type::C2C)     fftw_execute_dft    (pl, (fftw_complex*)&ip[0], (fftw_complex*)&op[0]);
+      else if (fft_type == FFT_Type::C2C_INV) fftw_execute_dft    (pl, (fftw_complex*)&ip[0], (fftw_complex*)&op[0]);
+      else                                    fftw_execute_dft_c2r(pl, (fftw_complex*)&ip[0], (double*)&op[0]);
     };
 
-    if (copy_input) { // preserve_input requested but FFTW destroys the input: copy to scratch.
+    if (preserve_input && !plan_preserve.fftwplan) { // no preserve plan (multi-D C2R): copy to scratch
       ScratchBuf<ValueType> tmp(N0);
       Iterator<ValueType> t = tmp.begin();
       ConstIterator<ValueType> src = in.begin();
       #pragma omp parallel for schedule(static)
       for (Long i = 0; i < N0; i++) t[i] = src[i];
-      exec(t, out);
-    } else { // input may be overwritten by FFTW.
-      exec(in.begin(), out);
+      exec(plan.fftwplan, t, out);
+    } else { // preserve-plan, else fast destroy-plan (may overwrite in)
+      exec(preserve_input ? plan_preserve.fftwplan : plan.fftwplan, in.begin(), out);
     }
   }
 #endif
@@ -1053,13 +1047,14 @@ namespace sctl {
 
   template <> inline FFT<float>::~FFT() {
     if (plan.fftwplan) fftwf_destroy_plan(plan.fftwplan);
+    if (plan_preserve.fftwplan) fftwf_destroy_plan(plan_preserve.fftwplan);
     plan.fftwplan = nullptr;
+    plan_preserve.fftwplan = nullptr;
   }
 
-  template <> inline void FFT<float>::Setup(FFT_Type fft_type_, Long howmany_, const Vector<Long>& dim_vec, Integer Nthreads, bool preserve_input) {
+  template <> inline void FFT<float>::Setup(FFT_Type fft_type_, Long howmany_, const Vector<Long>& dim_vec, Integer Nthreads) {
     fft_type = fft_type_;
     this->howmany_ = howmany_;
-    copy_input = false;
 
     Long rank = dim_vec.Dim();
     Vector<int> dim_vec_(rank);
@@ -1093,65 +1088,52 @@ namespace sctl {
     if (!N0 || !N1) return;
     Vector<float> in (N0), out(N1);
 
+    auto mkplan = [&](unsigned flags) -> fftwf_plan {
+      if      (fft_type == FFT_Type::R2C)     return fftwf_plan_many_dft_r2c(rank, &dim_vec_[0], this->howmany_, &in[0], nullptr, 1, N0 / this->howmany_, (fftwf_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, flags);
+      else if (fft_type == FFT_Type::C2C)     return fftwf_plan_many_dft    (rank, &dim_vec_[0], this->howmany_, (fftwf_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwf_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_FORWARD, flags);
+      else if (fft_type == FFT_Type::C2C_INV) return fftwf_plan_many_dft    (rank, &dim_vec_[0], this->howmany_, (fftwf_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwf_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_BACKWARD, flags);
+      else                                    return fftwf_plan_many_dft_c2r(rank, &dim_vec_[0], this->howmany_, (fftwf_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, &out[0], nullptr, 1, N1 / this->howmany_, flags);
+    };
     #pragma omp critical(SCTL_FFTW_PLAN)
     {
     FFTWInitThreads(Nthreads);
     if (plan.fftwplan) fftwf_destroy_plan(plan.fftwplan);
-    plan.fftwplan = nullptr;
-    if (preserve_input) { // Try a plan that preserves its input.
-      if (fft_type == FFT_Type::R2C) {
-        plan.fftwplan = fftwf_plan_many_dft_r2c(rank, &dim_vec_[0], this->howmany_, &in[0], nullptr, 1, N0 / this->howmany_, (fftwf_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      } else if (fft_type == FFT_Type::C2C) {
-        plan.fftwplan = fftwf_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftwf_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwf_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_FORWARD, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      } else if (fft_type == FFT_Type::C2C_INV) {
-        plan.fftwplan = fftwf_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftwf_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwf_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_BACKWARD, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      } else if (fft_type == FFT_Type::C2R) {
-        plan.fftwplan = fftwf_plan_many_dft_c2r(rank, &dim_vec_[0], this->howmany_, (fftwf_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, &out[0], nullptr, 1, N1 / this->howmany_, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      }
-      // Multi-dim C2R has no preserve-input plan: fall back to copying the input.
-      if (!plan.fftwplan) copy_input = true;
-    }
-    if (!plan.fftwplan) { // Build plan without FFTW_PRESERVE_INPUT (may destroy input).
-      if (fft_type == FFT_Type::R2C) {
-        plan.fftwplan = fftwf_plan_many_dft_r2c(rank, &dim_vec_[0], this->howmany_, &in[0], nullptr, 1, N0 / this->howmany_, (fftwf_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_ESTIMATE);
-      } else if (fft_type == FFT_Type::C2C) {
-        plan.fftwplan = fftwf_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftwf_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwf_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_FORWARD, FFTW_ESTIMATE);
-      } else if (fft_type == FFT_Type::C2C_INV) {
-        plan.fftwplan = fftwf_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftwf_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwf_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_BACKWARD, FFTW_ESTIMATE);
-      } else if (fft_type == FFT_Type::C2R) {
-        plan.fftwplan = fftwf_plan_many_dft_c2r(rank, &dim_vec_[0], this->howmany_, (fftwf_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, &out[0], nullptr, 1, N1 / this->howmany_, FFTW_ESTIMATE);
-      }
-    }
+    if (plan_preserve.fftwplan) fftwf_destroy_plan(plan_preserve.fftwplan);
+    plan.fftwplan = mkplan(FFTW_ESTIMATE);
+    plan_preserve.fftwplan = mkplan(FFTW_ESTIMATE | FFTW_PRESERVE_INPUT); // null for multi-D C2R
     }
     SCTL_ASSERT(plan.fftwplan);
+    align_in  = fftwf_alignment_of(&in[0]);  // for Execute's alignment assert
+    align_out = fftwf_alignment_of(&out[0]);
   }
 
-  template <> inline void FFT<float>::Execute(const Vector<float>& in, Vector<float>& out) const {
+  template <> inline void FFT<float>::ExecuteImpl(const Vector<float>& in, Vector<float>& out, bool preserve_input) const {
     using ValueType = float;
     Long N0 = Dim(0);
     Long N1 = Dim(1);
     if (!N0 || !N1) return;
     SCTL_ASSERT_MSG(in.Dim() == N0, "FFT: Wrong input size.");
     if (out.Dim() != N1) out.ReInit(N1);
-    //check_align(in, out);
 
-    // Unnormalized (raw FFTW) transform: no scaling is applied.
-    auto exec = [this](ConstIterator<ValueType> ip, Vector<ValueType>& op) {
-      if      (fft_type == FFT_Type::R2C)     fftwf_execute_dft_r2c(plan.fftwplan, (float*)&ip[0], (fftwf_complex*)&op[0]);
-      else if (fft_type == FFT_Type::C2C)     fftwf_execute_dft    (plan.fftwplan, (fftwf_complex*)&ip[0], (fftwf_complex*)&op[0]);
-      else if (fft_type == FFT_Type::C2C_INV) fftwf_execute_dft    (plan.fftwplan, (fftwf_complex*)&ip[0], (fftwf_complex*)&op[0]);
-      else                                    fftwf_execute_dft_c2r(plan.fftwplan, (fftwf_complex*)&ip[0], (float*)&op[0]);
+    // raw FFTW (unnormalized)
+    auto exec = [this](fftwf_plan pl, ConstIterator<ValueType> ip, Vector<ValueType>& op) {
+      SCTL_ASSERT_MSG(fftwf_alignment_of((ValueType*)&ip[0]) == align_in,  "FFT: input not aligned to plan (see Execute docs).");
+      SCTL_ASSERT_MSG(fftwf_alignment_of((ValueType*)&op[0]) == align_out, "FFT: output not aligned to plan (see Execute docs).");
+      if      (fft_type == FFT_Type::R2C)     fftwf_execute_dft_r2c(pl, (float*)&ip[0], (fftwf_complex*)&op[0]);
+      else if (fft_type == FFT_Type::C2C)     fftwf_execute_dft    (pl, (fftwf_complex*)&ip[0], (fftwf_complex*)&op[0]);
+      else if (fft_type == FFT_Type::C2C_INV) fftwf_execute_dft    (pl, (fftwf_complex*)&ip[0], (fftwf_complex*)&op[0]);
+      else                                    fftwf_execute_dft_c2r(pl, (fftwf_complex*)&ip[0], (float*)&op[0]);
     };
 
-    if (copy_input) { // preserve_input requested but FFTW destroys the input: copy to scratch.
+    if (preserve_input && !plan_preserve.fftwplan) { // no preserve plan (multi-D C2R): copy to scratch
       ScratchBuf<ValueType> tmp(N0);
       Iterator<ValueType> t = tmp.begin();
       ConstIterator<ValueType> src = in.begin();
       #pragma omp parallel for schedule(static)
       for (Long i = 0; i < N0; i++) t[i] = src[i];
-      exec(t, out);
-    } else { // input may be overwritten by FFTW.
-      exec(in.begin(), out);
+      exec(plan.fftwplan, t, out);
+    } else { // preserve-plan, else fast destroy-plan (may overwrite in)
+      exec(preserve_input ? plan_preserve.fftwplan : plan.fftwplan, in.begin(), out);
     }
   }
 
@@ -1165,13 +1147,14 @@ namespace sctl {
 
   template <> inline FFT<long double>::~FFT() {
     if (plan.fftwplan) fftwl_destroy_plan(plan.fftwplan);
+    if (plan_preserve.fftwplan) fftwl_destroy_plan(plan_preserve.fftwplan);
     plan.fftwplan = nullptr;
+    plan_preserve.fftwplan = nullptr;
   }
 
-  template <> inline void FFT<long double>::Setup(FFT_Type fft_type_, Long howmany_, const Vector<Long>& dim_vec, Integer Nthreads, bool preserve_input) {
+  template <> inline void FFT<long double>::Setup(FFT_Type fft_type_, Long howmany_, const Vector<Long>& dim_vec, Integer Nthreads) {
     fft_type = fft_type_;
     this->howmany_ = howmany_;
-    copy_input = false;
 
     Long rank = dim_vec.Dim();
     Vector<int> dim_vec_(rank);
@@ -1203,65 +1186,52 @@ namespace sctl {
     if (!N0 || !N1) return;
     Vector<long double> in (N0), out(N1);
 
+    auto mkplan = [&](unsigned flags) -> fftwl_plan {
+      if      (fft_type == FFT_Type::R2C)     return fftwl_plan_many_dft_r2c(rank, &dim_vec_[0], this->howmany_, &in[0], nullptr, 1, N0 / this->howmany_, (fftwl_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, flags);
+      else if (fft_type == FFT_Type::C2C)     return fftwl_plan_many_dft    (rank, &dim_vec_[0], this->howmany_, (fftwl_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwl_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_FORWARD, flags);
+      else if (fft_type == FFT_Type::C2C_INV) return fftwl_plan_many_dft    (rank, &dim_vec_[0], this->howmany_, (fftwl_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwl_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_BACKWARD, flags);
+      else                                    return fftwl_plan_many_dft_c2r(rank, &dim_vec_[0], this->howmany_, (fftwl_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, &out[0], nullptr, 1, N1 / this->howmany_, flags);
+    };
     #pragma omp critical(SCTL_FFTW_PLAN)
     {
     FFTWInitThreads(Nthreads);
     if (plan.fftwplan) fftwl_destroy_plan(plan.fftwplan);
-    plan.fftwplan = nullptr;
-    if (preserve_input) { // Try a plan that preserves its input.
-      if (fft_type == FFT_Type::R2C) {
-        plan.fftwplan = fftwl_plan_many_dft_r2c(rank, &dim_vec_[0], this->howmany_, &in[0], nullptr, 1, N0 / this->howmany_, (fftwl_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      } else if (fft_type == FFT_Type::C2C) {
-        plan.fftwplan = fftwl_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftwl_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwl_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_FORWARD, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      } else if (fft_type == FFT_Type::C2C_INV) {
-        plan.fftwplan = fftwl_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftwl_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwl_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_BACKWARD, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      } else if (fft_type == FFT_Type::C2R) {
-        plan.fftwplan = fftwl_plan_many_dft_c2r(rank, &dim_vec_[0], this->howmany_, (fftwl_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, &out[0], nullptr, 1, N1 / this->howmany_, FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
-      }
-      // Multi-dim C2R has no preserve-input plan: fall back to copying the input.
-      if (!plan.fftwplan) copy_input = true;
-    }
-    if (!plan.fftwplan) { // Build plan without FFTW_PRESERVE_INPUT (may destroy input).
-      if (fft_type == FFT_Type::R2C) {
-        plan.fftwplan = fftwl_plan_many_dft_r2c(rank, &dim_vec_[0], this->howmany_, &in[0], nullptr, 1, N0 / this->howmany_, (fftwl_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_ESTIMATE);
-      } else if (fft_type == FFT_Type::C2C) {
-        plan.fftwplan = fftwl_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftwl_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwl_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_FORWARD, FFTW_ESTIMATE);
-      } else if (fft_type == FFT_Type::C2C_INV) {
-        plan.fftwplan = fftwl_plan_many_dft(rank, &dim_vec_[0], this->howmany_, (fftwl_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, (fftwl_complex*)&out[0], nullptr, 1, N1 / 2 / this->howmany_, FFTW_BACKWARD, FFTW_ESTIMATE);
-      } else if (fft_type == FFT_Type::C2R) {
-        plan.fftwplan = fftwl_plan_many_dft_c2r(rank, &dim_vec_[0], this->howmany_, (fftwl_complex*)&in[0], nullptr, 1, N0 / 2 / this->howmany_, &out[0], nullptr, 1, N1 / this->howmany_, FFTW_ESTIMATE);
-      }
-    }
+    if (plan_preserve.fftwplan) fftwl_destroy_plan(plan_preserve.fftwplan);
+    plan.fftwplan = mkplan(FFTW_ESTIMATE);
+    plan_preserve.fftwplan = mkplan(FFTW_ESTIMATE | FFTW_PRESERVE_INPUT); // null for multi-D C2R
     }
     SCTL_ASSERT(plan.fftwplan);
+    align_in  = fftwl_alignment_of(&in[0]);  // for Execute's alignment assert
+    align_out = fftwl_alignment_of(&out[0]);
   }
 
-  template <> inline void FFT<long double>::Execute(const Vector<long double>& in, Vector<long double>& out) const {
+  template <> inline void FFT<long double>::ExecuteImpl(const Vector<long double>& in, Vector<long double>& out, bool preserve_input) const {
     using ValueType = long double;
     Long N0 = Dim(0);
     Long N1 = Dim(1);
     if (!N0 || !N1) return;
     SCTL_ASSERT_MSG(in.Dim() == N0, "FFT: Wrong input size.");
     if (out.Dim() != N1) out.ReInit(N1);
-    //check_align(in, out);
 
-    // Unnormalized (raw FFTW) transform: no scaling is applied.
-    auto exec = [this](ConstIterator<ValueType> ip, Vector<ValueType>& op) {
-      if      (fft_type == FFT_Type::R2C)     fftwl_execute_dft_r2c(plan.fftwplan, (long double*)&ip[0], (fftwl_complex*)&op[0]);
-      else if (fft_type == FFT_Type::C2C)     fftwl_execute_dft    (plan.fftwplan, (fftwl_complex*)&ip[0], (fftwl_complex*)&op[0]);
-      else if (fft_type == FFT_Type::C2C_INV) fftwl_execute_dft    (plan.fftwplan, (fftwl_complex*)&ip[0], (fftwl_complex*)&op[0]);
-      else                                    fftwl_execute_dft_c2r(plan.fftwplan, (fftwl_complex*)&ip[0], (long double*)&op[0]);
+    // raw FFTW (unnormalized)
+    auto exec = [this](fftwl_plan pl, ConstIterator<ValueType> ip, Vector<ValueType>& op) {
+      SCTL_ASSERT_MSG(fftwl_alignment_of((ValueType*)&ip[0]) == align_in,  "FFT: input not aligned to plan (see Execute docs).");
+      SCTL_ASSERT_MSG(fftwl_alignment_of((ValueType*)&op[0]) == align_out, "FFT: output not aligned to plan (see Execute docs).");
+      if      (fft_type == FFT_Type::R2C)     fftwl_execute_dft_r2c(pl, (long double*)&ip[0], (fftwl_complex*)&op[0]);
+      else if (fft_type == FFT_Type::C2C)     fftwl_execute_dft    (pl, (fftwl_complex*)&ip[0], (fftwl_complex*)&op[0]);
+      else if (fft_type == FFT_Type::C2C_INV) fftwl_execute_dft    (pl, (fftwl_complex*)&ip[0], (fftwl_complex*)&op[0]);
+      else                                    fftwl_execute_dft_c2r(pl, (fftwl_complex*)&ip[0], (long double*)&op[0]);
     };
 
-    if (copy_input) { // preserve_input requested but FFTW destroys the input: copy to scratch.
+    if (preserve_input && !plan_preserve.fftwplan) { // no preserve plan (multi-D C2R): copy to scratch
       ScratchBuf<ValueType> tmp(N0);
       Iterator<ValueType> t = tmp.begin();
       ConstIterator<ValueType> src = in.begin();
       #pragma omp parallel for schedule(static)
       for (Long i = 0; i < N0; i++) t[i] = src[i];
-      exec(t, out);
-    } else { // input may be overwritten by FFTW.
-      exec(in.begin(), out);
+      exec(plan.fftwplan, t, out);
+    } else { // preserve-plan, else fast destroy-plan (may overwrite in)
+      exec(preserve_input ? plan_preserve.fftwplan : plan.fftwplan, in.begin(), out);
     }
   }
 #endif

--- a/include/sctl/sph_harm.hpp
+++ b/include/sctl/sph_harm.hpp
@@ -46,7 +46,7 @@ template <class Real> class SphericalHarmonics{
      * Compute spherical harmonic coefficients from grid values.
      * \param[in] X Grid values {X(t0,p0), X(t0,p1), ... , X(t1,p0), X(t1,p1), ... }, where, {cos(t0), cos(t1), ... } are the Gauss-Legendre nodes of order (Nt-1) in the interval [-1,1] and {p0, p1, ... } are equispaced in [0, 2*pi].
      * \param[in] Nt Number of grid points \theta \in (0,pi).
-     * \param[in] Np Number of grid points \phi \in (0,2*pi).
+     * \param[in] Np Number of grid points \phi \in (0,2*pi). Np*sizeof(Real) must be a multiple of 16 (FFT alignment; Np even for double).
      * \param[in] p Order of spherical harmonic expansion.
      * \param[in] arrange Arrangement of the coefficients.
      * \param[out] S Spherical harmonic coefficients.
@@ -59,7 +59,7 @@ template <class Real> class SphericalHarmonics{
      * \param[in] arrange Arrangement of the coefficients.
      * \param[in] p Order of spherical harmonic expansion.
      * \param[in] Nt Number of grid points \theta \in (0,pi).
-     * \param[in] Np Number of grid points \phi \in (0,2*pi).
+     * \param[in] Np Number of grid points \phi \in (0,2*pi). Np*sizeof(Real) must be a multiple of 16 (FFT alignment; Np even for double).
      * \param[out] X Grid values {X(t0,p0), X(t0,p1), ... , X(t1,p0), X(t1,p1), ... }, where, {cos(t0), cos(t1), ... } are the Gauss-Legendre nodes of order (Nt-1) in the interval [-1,1] and {p0, p1, ... } are equispaced in [0, 2*pi].
      * \param[out] X_theta \theta derivative of X evaluated at grid points.
      * \param[out] X_phi \phi derivative of X evaluated at grid points.
@@ -94,7 +94,7 @@ template <class Real> class SphericalHarmonics{
      * Compute vector spherical harmonic coefficients from grid values.
      * \param[in] X Grid values {X(t0,p0), X(t0,p1), ... , X(t1,p0), ... , Y(t0,p0), ... , Z(t0,p0), ... }, where, {cos(t0), cos(t1), ... } are the Gauss-Legendre nodes of order (Nt-1) in the interval [-1,1] and {p0, p1, ... } are equispaced in [0, 2*pi].
      * \param[in] Nt Number of grid points \theta \in (0,pi).
-     * \param[in] Np Number of grid points \phi \in (0,2*pi).
+     * \param[in] Np Number of grid points \phi \in (0,2*pi). Np*sizeof(Real) must be a multiple of 16 (FFT alignment; Np even for double).
      * \param[in] p Order of spherical harmonic expansion.
      * \param[in] arrange Arrangement of the coefficients.
      * \param[out] S Vector spherical harmonic coefficients.
@@ -107,7 +107,7 @@ template <class Real> class SphericalHarmonics{
      * \param[in] arrange Arrangement of the coefficients.
      * \param[in] p Order of spherical harmonic expansion.
      * \param[in] Nt Number of grid points \theta \in (0,pi).
-     * \param[in] Np Number of grid points \phi \in (0,2*pi).
+     * \param[in] Np Number of grid points \phi \in (0,2*pi). Np*sizeof(Real) must be a multiple of 16 (FFT alignment; Np even for double).
      * \param[out] X Grid values {X(t0,p0), X(t0,p1), ... , X(t1,p0), X(t1,p1), ... , Y(t0,p0), ... , Z(t0,p0), ... }, where, {cos(t0), cos(t1), ... } are the Gauss-Legendre nodes of order (Nt-1) in the interval [-1,1] and {p0, p1, ... } are equispaced in [0, 2*pi].
      */
     static void VecSHC2Grid(const Vector<Real>& S, SHCArrange arrange, Long p, Long Nt, Long Np, Vector<Real>& X);

--- a/include/sctl/sph_harm.txx
+++ b/include/sctl/sph_harm.txx
@@ -423,6 +423,7 @@ template <class Real> void SphericalHarmonics<Real>::test() {
 }
 
 template <class Real> void SphericalHarmonics<Real>::Grid2SHC(const Vector<Real>& X, Long Nt, Long Np, Long p1, Vector<Real>& S, SHCArrange arrange){
+  SCTL_ASSERT_MSG((Np*sizeof(Real)) % 16 == 0, "SphericalHarmonics: Np*sizeof(Real) must be a multiple of 16 (FFT alignment).");
   Long N = X.Dim() / (Np*Nt);
   assert(X.Dim() == N*Np*Nt);
 
@@ -433,6 +434,7 @@ template <class Real> void SphericalHarmonics<Real>::Grid2SHC(const Vector<Real>
 }
 
 template <class Real> void SphericalHarmonics<Real>::SHC2Grid(const Vector<Real>& S, SHCArrange arrange, Long p0, Long Nt, Long Np, Vector<Real>* X, Vector<Real>* X_theta, Vector<Real>* X_phi){
+  SCTL_ASSERT_MSG((Np*sizeof(Real)) % 16 == 0, "SphericalHarmonics: Np*sizeof(Real) must be a multiple of 16 (FFT alignment).");
   Vector<Real> B0;
   SHCArrange1(S, arrange, p0, B0);
   SHC2Grid_(B0, p0, Nt, Np, X, X_phi, X_theta);
@@ -780,6 +782,7 @@ template <class Real> void SphericalHarmonics<Real>::WriteVTK(const char* fname,
 
 
 template <class Real> void SphericalHarmonics<Real>::Grid2VecSHC(const Vector<Real>& X, Long Nt, Long Np, Long p0, Vector<Real>& S, SHCArrange arrange) {
+  SCTL_ASSERT_MSG((Np*sizeof(Real)) % 16 == 0, "SphericalHarmonics: Np*sizeof(Real) must be a multiple of 16 (FFT alignment).");
   Long N = X.Dim() / (Np*Nt);
   assert(X.Dim() == N*Np*Nt);
   assert(N % COORD_DIM == 0);
@@ -885,6 +888,7 @@ template <class Real> void SphericalHarmonics<Real>::Grid2VecSHC(const Vector<Re
 }
 
 template <class Real> void SphericalHarmonics<Real>::VecSHC2Grid(const Vector<Real>& S, SHCArrange arrange, Long p0, Long Nt, Long Np, Vector<Real>& X) {
+  SCTL_ASSERT_MSG((Np*sizeof(Real)) % 16 == 0, "SphericalHarmonics: Np*sizeof(Real) must be a multiple of 16 (FFT alignment).");
   Vector<Real> B0;
   SHCArrange1(S, arrange, p0, B0);
 
@@ -2957,7 +2961,7 @@ template <class Real> const FFT<Real>& SphericalHarmonics<Real>::OpFourierInv(Lo
   #pragma omp critical (SCTL_FFT_PLAN1)
   if(!Mf.Dim(0)){
     StaticArray<Long,1> fft_dim {Np};
-    Mf.Setup(FFT_Type::R2C, 1, Vector<Long>(1,fft_dim,false), 1, true); // Grid2SHC_ input is const: preserve it
+    Mf.Setup(FFT_Type::R2C, 1, Vector<Long>(1,fft_dim,false), 1);
   }
   return Mf;
 }


### PR DESCRIPTION
Make the FFT wrapper's input-preservation contract honest in the type system, and guard the (previously silent) alignment requirement.

- Replace the runtime `preserve_input` Setup flag with two Execute overloads: `Execute(const Vector&, Vector&)` preserves the input, and `Execute(Vector&, Vector&, bool preserve_input=false)` is destructive by default. The argument's const-ness now expresses intent (no const_cast surprise: a const input is never overwritten; a mutable one may be).
- Setup builds both a destroy-input and a preserve-input plan (the latter is null for multi-D C2R, where the preserve path falls back to a scratch copy). Plan creation is one-time and cheap relative to Execute.
- Add an `fftw_alignment_of`-based assert on both in/out in Execute, turning a misaligned buffer from an opaque FFTW segfault into a clear call-site error. Document the alignment contract on Execute.
- sph_harm: assert (and document) that Np*sizeof(Real) is a multiple of the 16 B FFT alignment in the public Grid2SHC/SHC2Grid/Grid2VecSHC/VecSHC2Grid.

Verified: test-fft and test-fft-fallback (FFTW and Cooley-Tukey fallback), test-sph-harm, and a MEMDEBUG+ASan/UBSan build all pass; preserve/destroy semantics and the misalignment assert checked directly.