### PR TITLE
stacktrace: avoid <mach-o/dyld.h> to fix g++ build on macOS 26 SDK

### DIFF
--- a/include/sctl/stacktrace.h
+++ b/include/sctl/stacktrace.h
@@ -11,8 +11,10 @@
                             // runtime VMAs to file-relative offsets for PIE
                             // executables and shared libraries.
 #ifdef __APPLE__
-#include <mach-o/dyld.h>    // for _NSGetExecutablePath
 #include <cstdint>          // for uint32_t
+// Forward-declare rather than #include <mach-o/dyld.h>: that header transitively
+// pulls <mach/message.h>, which fails to compile under g++ on the macOS 26 SDK.
+extern "C" int _NSGetExecutablePath(char* buf, uint32_t* bufsize);
 #endif
 
 #include "sctl/common.hpp"  // for SCTL_UNUSED, sctl


### PR DESCRIPTION
<mach-o/dyld.h> transitively includes <mach/message.h>, whose xnu_static_assert_struct_size(...) macro is left unexpanded under g++ on the macOS 26 SDK and breaks compilation ("expected constructor, destructor, or type conversion before '(' token").

The header was included only for _NSGetExecutablePath; forward-declare that extern "C" libSystem symbol instead and drop the include, sidestepping the mach/message.h cascade. Linux is unaffected (uses /proc/self/exe).