### PR TITLE
LagrangeInterp: capture src_nds by reference, not by value

### DIFF
--- a/include/sctl/lagrange-interp.txx
+++ b/include/sctl/lagrange-interp.txx
@@ -49,7 +49,7 @@ namespace sctl {
     Matrix<Real> M(Nsrc, Ntrg, wts.begin(), false);
 
     ScratchBuf<Real> w(Nsrc);
-    const Real normal_factor = [src_nds]() { // normalize
+    const Real normal_factor = [&src_nds]() { // normalize
       if (src_nds.Dim() < 2) return (Real)1;
       Real max_src = src_nds[0], min_src = src_nds[0];
       for (const auto x : src_nds) {
@@ -118,7 +118,7 @@ namespace sctl {
     if (df.Dim() != dof * N) df.ReInit(dof * N);
     if (dof * N == 0) return;
 
-    const Real normal_factor = [nds]() { // normalize
+    const Real normal_factor = [&nds]() { // normalize
       if (!nds.Dim()) return (Real)1;
       Real max_src = nds[0], min_src = nds[0];
       for (const auto x : nds) {


### PR DESCRIPTION
By-value capture copied a Vector, heap-allocating on every Interpolate and Derivative call; at high thread counts the allocator serializes and neither scales.

4M Interpolate calls (order 8, 1 target) on 2x64-core EPYC 7742:
  threads:      1        32       128
  before:  0.3533 s  0.2076 s  0.2247 s
  after:   0.2318 s  0.0074 s  0.0021 s

Results bit-identical.