### PR TITLE
ompUtils: add scan() overload that writes the seed

### DIFF
--- a/include/sctl/ompUtils.hpp
+++ b/include/sctl/ompUtils.hpp
@@ -175,6 +175,21 @@ template <class ConstIter, class Int> typename std::iterator_traits<ConstIter>::
  */
 template <class ConstIter, class Iter, class Int> void scan(ConstIter A, Iter B, Int cnt);
 
+/**
+ * Exclusive prefix sum that also writes the seed: sets `B[0] = seed`, then behaves exactly like
+ * `scan(A, B, cnt)`. Preferred over the 3-argument form, which leaves `B[0]` to the caller.
+ *
+ * @tparam ConstIter Iterator type for the input range.
+ * @tparam Iter Iterator type for the output range.
+ * @tparam Int Integer type for indexing.
+ *
+ * @param[in] A Beginning iterator of the input range (length `cnt`).
+ * @param[out] B Beginning iterator of the output range (length `cnt`); `B[0..cnt-1]` are written.
+ * @param[in] cnt Number of elements in each range.
+ * @param[in] seed Value written to `B[0]`; pass 0 to convert a count array to displacements.
+ */
+template <class ConstIter, class Iter, class Int> void scan(ConstIter A, Iter B, Int cnt, typename std::iterator_traits<Iter>::value_type seed);
+
 }  // end namespace omp_par
 }  // end namespace sctl
 

--- a/include/sctl/ompUtils.txx
+++ b/include/sctl/ompUtils.txx
@@ -373,6 +373,12 @@ template <class ConstIter, class Iter, class Int> void omp_par::scan(ConstIter A
   }
 }
 
+template <class ConstIter, class Iter, class Int> void omp_par::scan(ConstIter A, Iter B, Int cnt, typename std::iterator_traits<Iter>::value_type seed) {
+  if (cnt < (Int)1) return;
+  B[0] = seed;
+  omp_par::scan(A, B, cnt);
+}
+
 }  // end namespace
 
 #endif // _SCTL_OMPUTILS_TXX_

--- a/src/test-ompUtils.cpp
+++ b/src/test-ompUtils.cpp
@@ -127,6 +127,29 @@ int main() {
     sctl::omp_par::scan(cnt.begin(), dsp.begin(), (Long)cnt.size());
     Long expected[] = {0, 3, 8, 9, 13};
     for (size_t i = 0; i < cnt.size(); ++i) CHECK(dsp[i] == expected[i]);
+
+    // 4-argument overload writes the seed too, matching the 3-argument form
+    for (const Long seed : {(Long)0, (Long)100}) {
+      std::vector<Long> C(10, -1);
+      sctl::omp_par::scan(A.begin(), C.begin(), (Long)10, seed);
+      Long acc_ = seed;
+      for (Long i = 0; i < 10; ++i) {
+        CHECK(C[i] == acc_);
+        if (i < 9) acc_ += A[i];
+      }
+    }
+  }
+
+  // --- scan over a range long enough to take the multi-threaded path ---
+  std::printf("scan (parallel path) :\n");
+  {
+    const Long N = 100 * SCTL_GET_MAX_THREADS() + 1000;
+    std::vector<Long> A(N), B(N, -1), ref(N);
+    for (Long i = 0; i < N; ++i) A[i] = (i % 7) + 1;
+    ref[0] = 5;
+    for (Long i = 1; i < N; ++i) ref[i] = ref[i - 1] + A[i - 1];
+    sctl::omp_par::scan(A.begin(), B.begin(), N, (Long)5);
+    for (Long i = 0; i < N; ++i) CHECK(B[i] == ref[i]);
   }
 
   TEST_SUMMARY_RETURN();


### PR DESCRIPTION
scan(A, B, cnt) treats B[0] as a caller-supplied seed and never writes it, so an uninitialised B[0] silently corrupts the whole result -- with a ScratchBuf output it produced garbage displacements and an out-of-bounds write. The contract is documented, but every call site has to remember a separate `B[0] = 0;`.

Add scan(A, B, cnt, seed), which writes B[0] and then delegates. The existing implementation already propagates a non-zero B[0] correctly through the multi-threaded path (per-chunk offsets are accumulated from B[i*step_size-1]), so no algorithm changes are needed. The seed type is taken from iterator_traits<Iter> rather than a separate deduced parameter, so a literal 0 cannot select a type different from B's.

Also cover the multi-threaded path in test-ompUtils: the existing scan tests all used cnt=10, which never reaches the cnt >= 100*nthreads threshold, so that path had no coverage.