### PR TITLE
test-ompUtils: cover omp_par::sample_sort

### DIFF
--- a/src/test-ompUtils.cpp
+++ b/src/test-ompUtils.cpp
@@ -152,5 +152,26 @@ int main() {
     for (Long i = 0; i < N; ++i) CHECK(B[i] == ref[i]);
   }
 
+  // --- sample_sort: out-of-place, in-place, and a size past the parallel threshold ---
+  std::printf("sample_sort :\n");
+  {
+    struct Rec { Long key; char pad[88]; };           // ~96B, like BuildNearList's NodeData
+    auto by_key = [](const Rec& a, const Rec& b) { return a.key < b.key; };
+    for (const Long N : {(Long)5, (Long)1000, (Long)100 * SCTL_GET_MAX_THREADS() + 4321}) {
+      std::vector<Rec> A(N), B(N), ref(N);
+      for (Long i = 0; i < N; ++i) A[i].key = ((i * 2654435761u) % 100003);
+      ref = A;
+      std::stable_sort(ref.begin(), ref.end(), [](const Rec& a, const Rec& b){ return a.key < b.key; });
+
+      sctl::omp_par::sample_sort(A.data(), B.data(), N, by_key);   // out-of-place
+      for (Long i = 0; i < N; ++i) CHECK(B[i].key == ref[i].key);
+      for (Long i = 1; i < N; ++i) CHECK(B[i-1].key <= B[i].key);
+
+      std::vector<Rec> C = A;
+      sctl::omp_par::sample_sort(C.data(), C.data() + N, by_key);  // in-place overload
+      for (Long i = 0; i < N; ++i) CHECK(C[i].key == ref[i].key);
+    }
+  }
+
   TEST_SUMMARY_RETURN();
 }


### PR DESCRIPTION
sample_sort had no test coverage at all. Exercise both overloads (out-of-place and in-place) at N = 5, 1000, and 100*nthreads + 4321, so the last size clears the N < 64*nt threshold and takes the bucketed multi-threaded path rather than the std::sort fallback.

The record type is ~96 bytes with a separate key, matching BuildNearList's NodeData -- large records are what the bucketed path is designed for, and they exercise the scatter step rather than a trivially cheap swap. Keys repeat, so the result is compared against std::stable_sort on keys only, plus a sortedness check; sample_sort is not stable and the order of equal keys is unspecified.